### PR TITLE
Add database-backed user authentication

### DIFF
--- a/PersonalFinanceDB.sql
+++ b/PersonalFinanceDB.sql
@@ -16,6 +16,24 @@ CREATE SCHEMA IF NOT EXISTS `personal_finance_db` DEFAULT CHARACTER SET utf8mb4 
 USE `personal_finance_db` ;
 
 -- -----------------------------------------------------
+-- Table `personal_finance_db`.`Users`
+-- -----------------------------------------------------
+DROP TABLE IF EXISTS `personal_finance_db`.`Users` ;
+
+CREATE TABLE IF NOT EXISTS `personal_finance_db`.`Users` (
+  `user_id` INT NOT NULL AUTO_INCREMENT,
+  `username` VARCHAR(50) NOT NULL,
+  `email` VARCHAR(100) NULL,
+  `password` VARCHAR(255) NOT NULL,
+  `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`user_id`),
+  UNIQUE INDEX `username` (`username` ASC) VISIBLE,
+  UNIQUE INDEX `email` (`email` ASC) VISIBLE)
+ENGINE = InnoDB
+DEFAULT CHARACTER SET = utf8mb4
+COLLATE = utf8mb4_0900_ai_ci;
+
+-- -----------------------------------------------------
 -- Table `personal_finance_db`.`Categories`
 -- -----------------------------------------------------
 DROP TABLE IF EXISTS `personal_finance_db`.`Categories` ;
@@ -73,6 +91,11 @@ CREATE TABLE IF NOT EXISTS `personal_finance_db`.`Moviments` (
 ENGINE = InnoDB
 DEFAULT CHARACTER SET = utf8mb4
 COLLATE = utf8mb4_0900_ai_ci;
+
+
+-- Utente di esempio per l'accesso iniziale
+INSERT INTO `personal_finance_db`.`Users` (`username`, `email`, `password`)
+VALUES ('admin', 'admin@example.com', 'admin');
 
 
 SET SQL_MODE=@OLD_SQL_MODE;

--- a/src/it/unicas/project/template/address/model/dao/mysql/DAOMySQLSettings.java
+++ b/src/it/unicas/project/template/address/model/dao/mysql/DAOMySQLSettings.java
@@ -1,5 +1,6 @@
 package it.unicas.project.template.address.model.dao.mysql;
 
+import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -89,11 +90,20 @@ public class DAOMySQLSettings {
     }
 
 
-    public static Statement getStatement() throws SQLException{
-        if (currentDAOMySQLSettings == null){
+    public static Connection getConnection() throws SQLException {
+        if (currentDAOMySQLSettings == null) {
             currentDAOMySQLSettings = getDefaultDAOSettings();
         }
-        return DriverManager.getConnection("jdbc:mysql://" + currentDAOMySQLSettings.host  + "/" + currentDAOMySQLSettings.schema + PARAMETERS, currentDAOMySQLSettings.userName, currentDAOMySQLSettings.pwd).createStatement();
+
+        return DriverManager.getConnection(
+                "jdbc:mysql://" + currentDAOMySQLSettings.host + "/" + currentDAOMySQLSettings.schema + PARAMETERS,
+                currentDAOMySQLSettings.userName,
+                currentDAOMySQLSettings.pwd
+        );
+    }
+
+    public static Statement getStatement() throws SQLException{
+        return getConnection().createStatement();
     }
 
     public static void closeStatement(Statement st) throws SQLException{

--- a/src/it/unicas/project/template/address/view/LoginController.java
+++ b/src/it/unicas/project/template/address/view/LoginController.java
@@ -5,6 +5,12 @@ import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.control.PasswordField;
 import javafx.scene.control.TextField;
+import it.unicas.project.template.address.model.dao.mysql.DAOMySQLSettings;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 
 public class LoginController {
 
@@ -62,14 +68,15 @@ public class LoginController {
                 mainApp.showDashboard();
             }
         } else {
-            // Login fallito
-            showError("Username o password non validi.");
+            // Se non c'è già un messaggio d'errore specifico, mostriamo quello generico
+            if (errorLabel == null || !errorLabel.isVisible()) {
+                showError("Username o password non validi.");
+            }
         }
     }
 
     /**
-     * Logica di validazione delle credenziali.
-     * Per ora è hardcoded, in futuro qui farai la query al DB.
+     * Logica di validazione delle credenziali contro la tabella Users.
      */
     private boolean isValidCredentials(String user, String pass) {
         // Controllo campi vuoti
@@ -77,9 +84,21 @@ public class LoginController {
             return false;
         }
 
-        // TODO: Sostituire con controllo reale sul Database (DAO)
-        // Per ora accetta tutto purché non vuoto, oppure metti "admin" "admin"
-        return true;
+        try (Connection connection = DAOMySQLSettings.getConnection();
+             PreparedStatement statement = connection.prepareStatement(
+                     "SELECT 1 FROM Users WHERE username = ? AND password = ? LIMIT 1")) {
+
+            statement.setString(1, user.trim());
+            statement.setString(2, pass.trim());
+
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next();
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+            showError("Errore di connessione al database.");
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- validate login credentials against the Users table using a database query
- expose a reusable MySQL connection helper in `DAOMySQLSettings`
- add the Users table and a seed admin user to the database schema dump

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69258f87eca883339544546d1668b238)