### PR TITLE
Enhance dashboard area chart styling

### DIFF
--- a/src/it/unicas/project/template/address/view/Dashboard.fxml
+++ b/src/it/unicas/project/template/address/view/Dashboard.fxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.geometry.Insets?>
-<?import javafx.scene.chart.LineChart?>
+<?import javafx.scene.chart.AreaChart?>
 <?import javafx.scene.chart.CategoryAxis?>
 <?import javafx.scene.chart.NumberAxis?>
 <?import javafx.scene.control.ComboBox?>
@@ -221,14 +221,14 @@
                                             </children>
                                         </HBox>
                                         <!-- CHART: LineChart con punti e legenda -->
-                                        <LineChart fx:id="chartAndamento" createSymbols="true" legendVisible="true" minHeight="250.0" prefHeight="300.0" style="-fx-background-color: transparent;" verticalGridLinesVisible="false">
+                                        <AreaChart fx:id="chartAndamento" createSymbols="true" legendVisible="true" minHeight="250.0" prefHeight="300.0" style="-fx-background-color: transparent; -fx-stroke-line-cap: round; -fx-stroke-line-join: round;" verticalGridLinesVisible="false">
                                             <xAxis>
                                                 <CategoryAxis side="BOTTOM" tickLabelFill="#64748b" />
                                             </xAxis>
                                             <yAxis>
                                                 <NumberAxis side="LEFT" tickLabelFill="#64748b" />
                                             </yAxis>
-                                        </LineChart>
+                                        </AreaChart>
                                     </children>
                                 </VBox>
                             </children>

--- a/src/it/unicas/project/template/address/view/DashboardController.java
+++ b/src/it/unicas/project/template/address/view/DashboardController.java
@@ -3,9 +3,14 @@ package it.unicas.project.template.address.view;
 import it.unicas.project.template.address.MainApp;
 import it.unicas.project.template.address.model.Movimenti;
 import it.unicas.project.template.address.model.dao.mysql.MovimentiDAOMySQLImpl;
+import javafx.animation.FadeTransition;
+import javafx.animation.ParallelTransition;
+import javafx.animation.ScaleTransition;
+import javafx.application.Platform;
+import javafx.scene.Node;
 import javafx.fxml.FXML;
 import javafx.geometry.Pos;
-import javafx.scene.chart.LineChart;
+import javafx.scene.chart.AreaChart;
 import javafx.scene.chart.XYChart;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
@@ -30,7 +35,7 @@ public class DashboardController {
     @FXML private Label lblEntrate;
     @FXML private Label lblUscite;
     @FXML private Label lblPrevisione;
-    @FXML private LineChart<String, Number> chartAndamento;
+    @FXML private AreaChart<String, Number> chartAndamento;
     @FXML private ComboBox<String> cmbRange;
 
     // Contenitore per la lista dinamica
@@ -211,7 +216,7 @@ public class DashboardController {
             }
 
             chartAndamento.getData().addAll(serieEntrate, serieUscite);
-            chartAndamento.setAnimated(true);
+            chartAndamento.setAnimated(false);
             stylizeSeries(serieEntrate, "#16a34a");
             stylizeSeries(serieUscite, "#dc2626");
 
@@ -236,19 +241,76 @@ public class DashboardController {
     private void stylizeSeries(XYChart.Series<String, Number> series, String colorHex) {
         series.nodeProperty().addListener((obs, oldNode, newNode) -> {
             if (newNode != null) {
-                newNode.setStyle(String.format("-fx-stroke: %s; -fx-stroke-width: 2px;", colorHex));
+                applySeriesStroke(newNode, colorHex);
+                newNode.sceneProperty().addListener((sceneObs, oldScene, newScene) -> {
+                    if (newScene != null) {
+                        Platform.runLater(() -> applySeriesStroke(newNode, colorHex));
+                    }
+                });
             }
         });
 
+        int index = 0;
         for (XYChart.Data<String, Number> item : series.getData()) {
+            final int nodeIndex = index++;
             item.nodeProperty().addListener((obs, oldNode, newNode) -> {
                 if (newNode != null) {
-                    newNode.setStyle(String.format("-fx-background-color: white, %s;", colorHex));
-                    newNode.setScaleX(1.2);
-                    newNode.setScaleY(1.2);
+                    newNode.setStyle(String.format("-fx-background-color: white, %s; -fx-background-radius: 50%%, 50%%; -fx-padding: 6px;",
+                            toRgba(colorHex, 0.35)));
+                    newNode.setOpacity(0);
+                    newNode.setScaleX(0.6);
+                    newNode.setScaleY(0.6);
+
+                    ParallelTransition appear = new ParallelTransition(
+                            createFadeTransition(newNode),
+                            createScaleTransition(newNode)
+                    );
+                    appear.setDelay(Duration.millis(120L * nodeIndex));
+                    appear.play();
                 }
             });
         }
+    }
+
+    private void applySeriesStroke(Node seriesNode, String colorHex) {
+        seriesNode.setStyle(String.format("-fx-stroke: %s; -fx-stroke-width: 2px; -fx-stroke-line-cap: round; -fx-stroke-line-join: round;", colorHex));
+
+        Node fillRegion = seriesNode.lookup(".chart-series-area-fill");
+        if (fillRegion != null) {
+            fillRegion.setStyle(String.format("-fx-fill: linear-gradient(to bottom, %s 0%%, %s 100%%);",
+                    toRgba(colorHex, 0.35), toRgba(colorHex, 0.05)));
+        }
+
+        Node line = seriesNode.lookup(".chart-series-area-line");
+        if (line != null) {
+            line.setStyle(String.format("-fx-stroke: %s; -fx-stroke-width: 2px; -fx-stroke-line-cap: round; -fx-stroke-line-join: round;", colorHex));
+        }
+    }
+
+    private FadeTransition createFadeTransition(Node node) {
+        FadeTransition fade = new FadeTransition(Duration.millis(450), node);
+        fade.setFromValue(0);
+        fade.setToValue(1);
+        fade.setInterpolator(javafx.animation.Interpolator.EASE_BOTH);
+        return fade;
+    }
+
+    private ScaleTransition createScaleTransition(Node node) {
+        ScaleTransition scale = new ScaleTransition(Duration.millis(450), node);
+        scale.setFromX(0.6);
+        scale.setFromY(0.6);
+        scale.setToX(1.0);
+        scale.setToY(1.0);
+        scale.setInterpolator(javafx.animation.Interpolator.EASE_OUT);
+        return scale;
+    }
+
+    private String toRgba(String hexColor, double opacity) {
+        Color color = Color.web(hexColor);
+        int r = (int) Math.round(color.getRed() * 255);
+        int g = (int) Math.round(color.getGreen() * 255);
+        int b = (int) Math.round(color.getBlue() * 255);
+        return String.format("rgba(%d,%d,%d,%.2f)", r, g, b, opacity);
     }
 
 }


### PR DESCRIPTION
## Summary
- switch the dashboard financial chart to an AreaChart with smoother styling
- add gradient fills, rounded strokes, and animated symbol reveals per series
- preserve tooltips, per-series colors, and visible symbols for Entrate and Uscite

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69299cb529fc8333ae3a9c31e67a606d)