### PR TITLE
Fix SmoothAreaChart FXML axis configuration

### DIFF
--- a/bin/it/unicas/project/template/address/view/Dashboard.fxml
+++ b/bin/it/unicas/project/template/address/view/Dashboard.fxml
@@ -222,14 +222,7 @@
                                             </children>
                                         </HBox>
 
-                                        <SmoothAreaChart fx:id="chartAndamento" animated="true" createSymbols="false" legendVisible="true" minHeight="250.0" prefHeight="300.0" verticalGridLinesVisible="false">
-                                            <xAxis>
-                                                <CategoryAxis side="BOTTOM" />
-                                            </xAxis>
-                                            <yAxis>
-                                                <NumberAxis side="LEFT" />
-                                            </yAxis>
-                                        </SmoothAreaChart>
+                                        <SmoothAreaChart fx:id="chartAndamento" animated="true" createSymbols="false" legendVisible="true" minHeight="250.0" prefHeight="300.0" verticalGridLinesVisible="false" />
                                     </children>
                                 </VBox>
                             </children>

--- a/src/it/unicas/project/template/address/view/Dashboard.fxml
+++ b/src/it/unicas/project/template/address/view/Dashboard.fxml
@@ -222,14 +222,7 @@
                                             </children>
                                         </HBox>
 
-                                        <SmoothAreaChart fx:id="chartAndamento" animated="true" createSymbols="false" legendVisible="true" minHeight="250.0" prefHeight="300.0" verticalGridLinesVisible="false">
-                                            <xAxis>
-                                                <CategoryAxis side="BOTTOM" />
-                                            </xAxis>
-                                            <yAxis>
-                                                <NumberAxis side="LEFT" />
-                                            </yAxis>
-                                        </SmoothAreaChart>
+                                        <SmoothAreaChart fx:id="chartAndamento" animated="true" createSymbols="false" legendVisible="true" minHeight="250.0" prefHeight="300.0" verticalGridLinesVisible="false" />
                                     </children>
                                 </VBox>
                             </children>


### PR DESCRIPTION
## Summary
- remove explicit axis definitions from the SmoothAreaChart in Dashboard.fxml so it can be loaded without property errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929d5183e208333897c473e5a0c2abb)