### PR TITLE
Clamp smoothing control points to baseline

### DIFF
--- a/src/it/unicas/project/template/address/view/SmoothAreaChart.java
+++ b/src/it/unicas/project/template/address/view/SmoothAreaChart.java
@@ -62,7 +62,13 @@ public class SmoothAreaChart<X, Y> extends AreaChart<X, Y> {
 
         // Genera i segmenti curvi
         List<PathElement> smoothElements = new ArrayList<>();
-        smoothElements.add(new MoveTo(points.get(0).x, points.get(0).y));
+
+        double yZero = ((Axis) getYAxis()).getDisplayPosition(0);
+        double baselineY = Double.isNaN(yZero)
+                ? points.stream().mapToDouble(p -> p.y).max().orElse(getHeight())
+                : yZero;
+
+        smoothElements.add(new MoveTo(points.get(0).x, clampToBaseline(points.get(0).y, baselineY)));
 
         for (int i = 0; i < points.size() - 1; i++) {
             Point2D p0 = (i > 0) ? points.get(i - 1) : points.get(i);
@@ -70,10 +76,10 @@ public class SmoothAreaChart<X, Y> extends AreaChart<X, Y> {
             Point2D p2 = points.get(i + 1);
             Point2D p3 = (i < points.size() - 2) ? points.get(i + 2) : points.get(i + 1);
 
-            Point2D cp1 = getControlPoint(p0, p1, p2, false);
-            Point2D cp2 = getControlPoint(p1, p2, p3, true);
+            Point2D cp1 = clampToBaseline(getControlPoint(p0, p1, p2, false), baselineY);
+            Point2D cp2 = clampToBaseline(getControlPoint(p1, p2, p3, true), baselineY);
 
-            smoothElements.add(new CubicCurveTo(cp1.x, cp1.y, cp2.x, cp2.y, p2.x, p2.y));
+            smoothElements.add(new CubicCurveTo(cp1.x, cp1.y, cp2.x, cp2.y, p2.x, clampToBaseline(p2.y, baselineY)));
         }
 
         // Applica al percorso della linea
@@ -84,7 +90,7 @@ public class SmoothAreaChart<X, Y> extends AreaChart<X, Y> {
             List<PathElement> fillElements = new ArrayList<>(smoothElements);
             // Chiudi il percorso di riempimento verso l'asse X
             double yZero = ((Axis) getYAxis()).getDisplayPosition(0);
-            if (Double.isNaN(yZero)) yZero = getHeight(); // Fallback se l'asse non è pronto
+            if (Double.isNaN(yZero)) yZero = baselineY; // Fallback se l'asse non è pronto
 
             fillElements.add(new LineTo(points.get(points.size() - 1).x, yZero));
             fillElements.add(new LineTo(points.get(0).x, yZero));
@@ -113,6 +119,14 @@ public class SmoothAreaChart<X, Y> extends AreaChart<X, Y> {
                     p1.y + (tension * (p2.y - p0.y) * d1) / (d1 + d2)
             );
         }
+    }
+
+    private double clampToBaseline(double value, double baseline) {
+        return Math.min(value, baseline);
+    }
+
+    private Point2D clampToBaseline(Point2D point, double baseline) {
+        return new Point2D(point.x, clampToBaseline(point.y, baseline));
     }
 
     private static class Point2D {


### PR DESCRIPTION
## Summary
- clamp SmoothAreaChart control points and endpoints to the zero-axis baseline to avoid negative overshoot
- reuse the same baseline when closing the filled area to keep rendering above the X-axis

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929de307148833397bad7a68c87c568)