### PR TITLE
Ensure SmoothAreaChart Y-axis starts at zero

### DIFF
--- a/src/it/unicas/project/template/address/view/SmoothAreaChart.java
+++ b/src/it/unicas/project/template/address/view/SmoothAreaChart.java
@@ -22,7 +22,13 @@ public class SmoothAreaChart<X, Y> extends AreaChart<X, Y> {
     public SmoothAreaChart() {
         // Creiamo degli assi di default per permettere l'inizializzazione da FXML
         // Il casting (Axis<X>) è necessario per soddisfare i generici
-        super((Axis<X>) new CategoryAxis(), (Axis<Y>) new NumberAxis());
+        NumberAxis defaultYAxis = new NumberAxis();
+        defaultYAxis.setAutoRanging(false);
+        defaultYAxis.setLowerBound(0);
+        defaultYAxis.setUpperBound(100);
+        defaultYAxis.setTickUnit(10);
+
+        super((Axis<X>) new CategoryAxis(), (Axis<Y>) defaultYAxis);
     }
     // -------------------------------------
 


### PR DESCRIPTION
## Summary
- configure the default SmoothAreaChart Y-axis to start at zero
- set manual bounds and tick units on the default NumberAxis used by the FXML constructor

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929de321c088333a7b8e2c1c52c11b0)