### PR TITLE
Enable SmoothAreaChart symbols for tooltip display

### DIFF
--- a/src/it/unicas/project/template/address/view/Dashboard.fxml
+++ b/src/it/unicas/project/template/address/view/Dashboard.fxml
@@ -222,7 +222,7 @@
                                             </children>
                                         </HBox>
 
-                                        <SmoothAreaChart fx:id="chartAndamento" animated="true" createSymbols="false" legendVisible="true" minHeight="250.0" prefHeight="300.0" verticalGridLinesVisible="false" />
+                                        <SmoothAreaChart fx:id="chartAndamento" animated="true" createSymbols="true" legendVisible="true" minHeight="250.0" prefHeight="300.0" verticalGridLinesVisible="false" />
                                     </children>
                                 </VBox>
                             </children>


### PR DESCRIPTION
## Summary
- enable point symbols on the SmoothAreaChart so tooltips can appear on hover

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929de2db84483338b7a938a97fd9fbc)