### PR TITLE
Add category-specific budget limit warnings

### DIFF
--- a/src/it/unicas/project/template/address/util/BudgetNotificationHelper.java
+++ b/src/it/unicas/project/template/address/util/BudgetNotificationHelper.java
@@ -4,6 +4,8 @@ import it.unicas.project.template.address.model.Budget;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.control.Alert;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonBar;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
@@ -14,6 +16,7 @@ import javafx.stage.StageStyle;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Helper class per gestire le notifiche di superamento budget.
@@ -22,10 +25,74 @@ import java.util.List;
 public class BudgetNotificationHelper {
 
     /**
+     * Controlla se una specifica categoria ha appena superato il budget e mostra la notifica.
+     * La notifica viene mostrata solo se:
+     * - Il budget è stato superato
+     * - La categoria NON era già stata notificata questo mese
+     * - Le notifiche per questa categoria NON sono disabilitate
+     *
+     * @param budgets Lista di tutti i budget del mese
+     * @param categoryId ID della categoria da controllare (quella del movimento appena inserito)
+     * @return true se la notifica è stata mostrata, false altrimenti
+     */
+    public static boolean checkAndNotifyForCategory(List<Budget> budgets, int categoryId) {
+        if (budgets == null || budgets.isEmpty()) {
+            return false;
+        }
+
+        // Ignora la categoria Stipendio (ID 6)
+        if (categoryId == 6) {
+            return false;
+        }
+
+        // Trova il budget per la categoria specifica
+        Budget categoryBudget = budgets.stream()
+            .filter(b -> b.getCategoryId() == categoryId)
+            .findFirst()
+            .orElse(null);
+
+        if (categoryBudget == null) {
+            return false;
+        }
+
+        // Controlla se il budget è stato superato
+        boolean isExceeded = categoryBudget.getSpentAmount() > categoryBudget.getBudgetAmount()
+            && categoryBudget.getBudgetAmount() > 0;
+
+        BudgetNotificationPreferences prefs = BudgetNotificationPreferences.getInstance();
+
+        if (!isExceeded) {
+            // Se il budget NON è più superato, rimuovi la marcatura
+            prefs.unmarkAsNotified(categoryId);
+            return false;
+        }
+
+        // Il budget è superato: controlla se mostrare la notifica
+        if (prefs.isNotificationDisabled(categoryId)) {
+            // Notifiche disabilitate per questa categoria
+            return false;
+        }
+
+        if (prefs.wasAlreadyNotifiedThisMonth(categoryId)) {
+            // Già notificato questo mese, mostra comunque il popup
+            // (l'utente ha inserito un altro movimento nella stessa categoria)
+            showSingleBudgetExceededAlert(categoryBudget);
+            return true;
+        }
+
+        // Prima volta che supera il budget questo mese: mostra notifica e segna
+        prefs.markAsNotified(categoryId);
+        showSingleBudgetExceededAlert(categoryBudget);
+        return true;
+    }
+
+    /**
      * Controlla se ci sono budget superati nella lista fornita e mostra una notifica di allarme.
      * @param budgets Lista di budget da controllare
      * @return true se almeno un budget è stato superato, false altrimenti
+     * @deprecated Usare checkAndNotifyForCategory per notifiche per singola categoria
      */
+    @Deprecated
     public static boolean checkAndNotifyBudgetExceeded(List<Budget> budgets) {
         if (budgets == null || budgets.isEmpty()) {
             return false;
@@ -52,9 +119,118 @@ public class BudgetNotificationHelper {
     }
 
     /**
+     * Mostra un popup di allarme per una singola categoria che ha superato il budget.
+     * Include il bottone "Non mostrare più" per disabilitare le notifiche.
+     */
+    private static void showSingleBudgetExceededAlert(Budget budget) {
+        Alert alert = new Alert(Alert.AlertType.WARNING);
+        alert.setTitle("⚠️ ALLARME BUDGET SUPERATO");
+        alert.setHeaderText(null);
+        alert.initStyle(StageStyle.DECORATED);
+
+        // Crea il contenuto personalizzato
+        VBox content = new VBox(15);
+        content.setPadding(new Insets(20));
+        content.setStyle("-fx-background-color: #fff5f5;");
+
+        // Titolo con icona
+        HBox titleBox = new HBox(10);
+        titleBox.setAlignment(Pos.CENTER);
+
+        Label warningIcon = new Label("⚠️");
+        warningIcon.setStyle("-fx-font-size: 36px;");
+
+        Label titleLabel = new Label("ATTENZIONE: Budget Superato!");
+        titleLabel.setFont(Font.font("System", FontWeight.BOLD, 20));
+        titleLabel.setStyle("-fx-text-fill: #dc2626;");
+
+        titleBox.getChildren().addAll(warningIcon, titleLabel);
+
+        // Messaggio principale
+        Label messageLabel = new Label("Hai superato il budget mensile per la seguente categoria:");
+        messageLabel.setFont(Font.font("System", FontWeight.NORMAL, 14));
+        messageLabel.setStyle("-fx-text-fill: #991b1b;");
+        messageLabel.setWrapText(true);
+
+        // Box per la categoria superata
+        VBox categoryBox = new VBox(10);
+        categoryBox.setPadding(new Insets(15));
+        categoryBox.setStyle("-fx-background-color: white; -fx-border-color: #f87171; " +
+                           "-fx-border-width: 2; -fx-border-radius: 8; -fx-background-radius: 8;");
+
+        HBox categoryRow = new HBox(10);
+        categoryRow.setAlignment(Pos.CENTER_LEFT);
+
+        // Icona di allarme
+        Label exclamation = new Label("❗");
+        exclamation.setStyle("-fx-font-size: 24px;");
+
+        // Dettagli categoria
+        VBox details = new VBox(5);
+
+        Label categoryName = new Label(budget.getCategoryName());
+        categoryName.setFont(Font.font("System", FontWeight.BOLD, 16));
+        categoryName.setStyle("-fx-text-fill: #dc2626;");
+
+        double exceeded = budget.getSpentAmount() - budget.getBudgetAmount();
+        double percentage = (budget.getSpentAmount() / budget.getBudgetAmount()) * 100;
+
+        Label amountInfo = new Label(String.format(
+            "Budget: €%.2f | Speso: €%.2f | Superato di: €%.2f (%.0f%%)",
+            budget.getBudgetAmount(), budget.getSpentAmount(), exceeded, percentage
+        ));
+        amountInfo.setFont(Font.font("System", FontWeight.NORMAL, 13));
+        amountInfo.setStyle("-fx-text-fill: #7f1d1d;");
+
+        details.getChildren().addAll(categoryName, amountInfo);
+        categoryRow.getChildren().addAll(exclamation, details);
+        categoryBox.getChildren().add(categoryRow);
+
+        // Messaggio di suggerimento
+        Label suggestionLabel = new Label("💡 Suggerimento: Rivedi le tue spese o aumenta il limite del budget.");
+        suggestionLabel.setFont(Font.font("System", FontWeight.NORMAL, 12));
+        suggestionLabel.setStyle("-fx-text-fill: #ea580c; -fx-font-style: italic;");
+        suggestionLabel.setWrapText(true);
+
+        content.getChildren().addAll(titleBox, messageLabel, categoryBox, suggestionLabel);
+
+        alert.getDialogPane().setContent(content);
+        alert.getDialogPane().setStyle("-fx-background-color: #fff5f5;");
+
+        // Bottoni personalizzati: OK e "Non mostrare più"
+        ButtonType okButton = new ButtonType("OK", ButtonBar.ButtonData.OK_DONE);
+        ButtonType disableButton = new ButtonType("Non mostrare più", ButtonBar.ButtonData.OTHER);
+
+        alert.getButtonTypes().setAll(okButton, disableButton);
+
+        // Stile bottone OK
+        Button okBtn = (Button) alert.getDialogPane().lookupButton(okButton);
+        okBtn.setStyle(
+            "-fx-background-color: #dc2626; -fx-text-fill: white; " +
+            "-fx-font-weight: bold; -fx-padding: 10 20; -fx-font-size: 14px;"
+        );
+
+        // Stile bottone "Non mostrare più"
+        Button disableBtn = (Button) alert.getDialogPane().lookupButton(disableButton);
+        disableBtn.setStyle(
+            "-fx-background-color: #6b7280; -fx-text-fill: white; " +
+            "-fx-font-weight: normal; -fx-padding: 10 20; -fx-font-size: 13px;"
+        );
+
+        // Gestione click
+        Optional<ButtonType> result = alert.showAndWait();
+        if (result.isPresent() && result.get() == disableButton) {
+            // L'utente ha scelto "Non mostrare più"
+            BudgetNotificationPreferences.getInstance().disableNotificationForCategory(budget.getCategoryId());
+        }
+    }
+
+    /**
      * Mostra un popup di allarme personalizzato per i budget superati.
      * Stile: rosso/arancione con icone di warning.
+     * @deprecated Usare showSingleBudgetExceededAlert per notifiche singole
      */
+    @Deprecated
     private static void showBudgetExceededAlert(List<Budget> exceededBudgets) {
         Alert alert = new Alert(Alert.AlertType.WARNING);
         alert.setTitle("⚠️ ALLARME BUDGET SUPERATO");

--- a/src/it/unicas/project/template/address/util/BudgetNotificationPreferences.java
+++ b/src/it/unicas/project/template/address/util/BudgetNotificationPreferences.java
@@ -1,0 +1,224 @@
+package it.unicas.project.template.address.util;
+
+import java.io.*;
+import java.time.YearMonth;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Gestisce le preferenze per le notifiche di budget superato.
+ * Tiene traccia di:
+ * - Categorie con notifiche disabilitate permanentemente
+ * - Categorie già notificate come superate nel mese corrente
+ */
+public class BudgetNotificationPreferences {
+
+    private static final String PREFERENCES_FILE = "budget_notifications.json";
+    private static BudgetNotificationPreferences instance;
+
+    // Categorie con notifiche disabilitate permanentemente (categoryId)
+    private Set<Integer> disabledCategories;
+
+    // Mappa: mese-anno -> set di categoryId già notificati come superati
+    // Esempio: "2025-11" -> {1, 3, 5}
+    private Map<String, Set<Integer>> notifiedExceededCategories;
+
+    private BudgetNotificationPreferences() {
+        this.disabledCategories = new HashSet<>();
+        this.notifiedExceededCategories = new HashMap<>();
+        load();
+    }
+
+    public static synchronized BudgetNotificationPreferences getInstance() {
+        if (instance == null) {
+            instance = new BudgetNotificationPreferences();
+        }
+        return instance;
+    }
+
+    /**
+     * Verifica se una categoria ha le notifiche disabilitate permanentemente
+     */
+    public boolean isNotificationDisabled(int categoryId) {
+        return disabledCategories.contains(categoryId);
+    }
+
+    /**
+     * Disabilita permanentemente le notifiche per una categoria
+     */
+    public void disableNotificationForCategory(int categoryId) {
+        disabledCategories.add(categoryId);
+        save();
+    }
+
+    /**
+     * Riabilita le notifiche per una categoria
+     */
+    public void enableNotificationForCategory(int categoryId) {
+        disabledCategories.remove(categoryId);
+        save();
+    }
+
+    /**
+     * Verifica se una categoria è già stata notificata come superata nel mese corrente
+     */
+    public boolean wasAlreadyNotifiedThisMonth(int categoryId) {
+        String currentMonth = getCurrentMonthKey();
+        Set<Integer> notifiedThisMonth = notifiedExceededCategories.get(currentMonth);
+        return notifiedThisMonth != null && notifiedThisMonth.contains(categoryId);
+    }
+
+    /**
+     * Segna una categoria come notificata per il mese corrente
+     */
+    public void markAsNotified(int categoryId) {
+        String currentMonth = getCurrentMonthKey();
+        notifiedExceededCategories.computeIfAbsent(currentMonth, k -> new HashSet<>()).add(categoryId);
+        save();
+    }
+
+    /**
+     * Rimuove la marcatura di notifica per una categoria nel mese corrente
+     * (utile quando il budget torna sotto il limite)
+     */
+    public void unmarkAsNotified(int categoryId) {
+        String currentMonth = getCurrentMonthKey();
+        Set<Integer> notifiedThisMonth = notifiedExceededCategories.get(currentMonth);
+        if (notifiedThisMonth != null) {
+            notifiedThisMonth.remove(categoryId);
+            if (notifiedThisMonth.isEmpty()) {
+                notifiedExceededCategories.remove(currentMonth);
+            }
+            save();
+        }
+    }
+
+    /**
+     * Pulisce le notifiche di mesi vecchi (mantiene solo gli ultimi 3 mesi)
+     */
+    public void cleanOldMonths() {
+        YearMonth current = YearMonth.now();
+        Set<String> toRemove = new HashSet<>();
+
+        for (String monthKey : notifiedExceededCategories.keySet()) {
+            try {
+                YearMonth monthYear = YearMonth.parse(monthKey);
+                // Rimuovi se più vecchio di 3 mesi
+                if (monthYear.isBefore(current.minusMonths(3))) {
+                    toRemove.add(monthKey);
+                }
+            } catch (Exception e) {
+                // Chiave malformata, rimuovi
+                toRemove.add(monthKey);
+            }
+        }
+
+        toRemove.forEach(notifiedExceededCategories::remove);
+        if (!toRemove.isEmpty()) {
+            save();
+        }
+    }
+
+    /**
+     * Ottiene la chiave del mese corrente in formato "YYYY-MM"
+     */
+    private String getCurrentMonthKey() {
+        return YearMonth.now().toString();
+    }
+
+    /**
+     * Salva le preferenze su file di testo
+     * Formato:
+     * disabled=1,3,5
+     * notified.2025-11=1,3,5
+     * notified.2025-12=2,4
+     */
+    private void save() {
+        try (PrintWriter writer = new PrintWriter(new FileWriter(PREFERENCES_FILE))) {
+            // Salva categorie disabilitate
+            if (!disabledCategories.isEmpty()) {
+                writer.print("disabled=");
+                writer.println(String.join(",",
+                    disabledCategories.stream().map(String::valueOf).toArray(String[]::new)));
+            }
+
+            // Salva categorie notificate per mese
+            for (Map.Entry<String, Set<Integer>> entry : notifiedExceededCategories.entrySet()) {
+                if (!entry.getValue().isEmpty()) {
+                    writer.print("notified." + entry.getKey() + "=");
+                    writer.println(String.join(",",
+                        entry.getValue().stream().map(String::valueOf).toArray(String[]::new)));
+                }
+            }
+        } catch (IOException e) {
+            System.err.println("Errore nel salvataggio delle preferenze notifiche: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Carica le preferenze dal file di testo
+     */
+    private void load() {
+        File file = new File(PREFERENCES_FILE);
+        if (!file.exists()) {
+            return;
+        }
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                line = line.trim();
+                if (line.isEmpty() || line.startsWith("#")) {
+                    continue;
+                }
+
+                int equalsIndex = line.indexOf('=');
+                if (equalsIndex == -1) {
+                    continue;
+                }
+
+                String key = line.substring(0, equalsIndex);
+                String value = line.substring(equalsIndex + 1);
+
+                if (key.equals("disabled")) {
+                    // Carica categorie disabilitate
+                    if (!value.isEmpty()) {
+                        String[] ids = value.split(",");
+                        for (String id : ids) {
+                            try {
+                                disabledCategories.add(Integer.parseInt(id.trim()));
+                            } catch (NumberFormatException e) {
+                                // Ignora valori non validi
+                            }
+                        }
+                    }
+                } else if (key.startsWith("notified.")) {
+                    // Carica categorie notificate per mese
+                    String monthKey = key.substring("notified.".length());
+                    if (!value.isEmpty()) {
+                        String[] ids = value.split(",");
+                        Set<Integer> categoryIds = new HashSet<>();
+                        for (String id : ids) {
+                            try {
+                                categoryIds.add(Integer.parseInt(id.trim()));
+                            } catch (NumberFormatException e) {
+                                // Ignora valori non validi
+                            }
+                        }
+                        if (!categoryIds.isEmpty()) {
+                            notifiedExceededCategories.put(monthKey, categoryIds);
+                        }
+                    }
+                }
+            }
+
+            // Pulisci mesi vecchi al caricamento
+            cleanOldMonths();
+
+        } catch (IOException e) {
+            System.err.println("Errore nel caricamento delle preferenze notifiche: " + e.getMessage());
+        }
+    }
+}

--- a/src/it/unicas/project/template/address/view/BudgetController.java
+++ b/src/it/unicas/project/template/address/view/BudgetController.java
@@ -201,8 +201,8 @@ public class BudgetController {
             }
         }
 
-        // Controlla e notifica se ci sono budget superati
-        BudgetNotificationHelper.checkAndNotifyBudgetExceeded(currentBudgets);
+        // Le notifiche di budget superato vengono mostrate solo quando si inserisce un movimento,
+        // non quando si visualizza semplicemente la dashboard dei budget.
     }
 
     private void resetCard(Label remaining, Label spent, Label limit,


### PR DESCRIPTION
Modifiche principali:
- Le notifiche ora appaiono solo per la categoria del movimento appena inserito
- Il popup mostra solo la categoria che ha appena superato il budget, non tutte
- Aggiunto tracciamento intelligente: la notifica appare solo quando il budget viene effettivamente superato
- Aggiunto bottone "Non mostrare più" per disabilitare permanentemente le notifiche per categoria
- Se si inserisce un movimento che non fa superare alcun budget, non vengono mostrati popup di categorie già superate
- Rimosso popup automatico dalla dashboard Budget (solo visualizzazione)

Implementazione tecnica:
- Creata classe BudgetNotificationPreferences per gestire:
  * Categorie con notifiche disabilitate permanentemente
  * Tracciamento categorie già notificate nel mese corrente
  * Persistenza su file di testo semplice (no dipendenze esterne)
- Modificato BudgetNotificationHelper:
  * Nuovo metodo checkAndNotifyForCategory per notifiche singole
  * Nuovo popup singolo con bottone "Non mostrare più"
  * Metodi vecchi marcati come @Deprecated
- Modificato MovimentiController:
  * checkBudgetAfterTransaction ora accetta categoryId
  * Nuovo metodo checkBudgetAfterDeletion per gestire cancellazioni
  * Aggiornamento stato notifiche quando budget torna sotto il limite

Il sistema ora è più intelligente e meno invasivo per l'utente.