### PR TITLE
Add three-day dashboard bar chart

### DIFF
--- a/src/it/unicas/project/template/address/view/Dashboard.fxml
+++ b/src/it/unicas/project/template/address/view/Dashboard.fxml
@@ -2,6 +2,8 @@
 
 <?import it.unicas.project.template.address.view.SmoothAreaChart?>
 <?import javafx.geometry.Insets?>
+<?import javafx.scene.chart.BarChart?>
+<?import javafx.scene.chart.NumberAxis?>
 <?import javafx.scene.control.ComboBox?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.ScrollPane?>
@@ -208,6 +210,20 @@
                                         </HBox>
 
                                         <SmoothAreaChart fx:id="chartAndamento" animated="true" createSymbols="true" legendVisible="true" minHeight="250.0" prefHeight="300.0" verticalGridLinesVisible="false" />
+
+                                        <Label text="Entrate e uscite per intervalli di 3 giorni (mese corrente)" textFill="#1e293b">
+                                            <font>
+                                                <Font name="System Bold" size="16.0" />
+                                            </font>
+                                        </Label>
+                                        <BarChart fx:id="chartThreeDay" legendVisible="true" prefHeight="260.0" verticalGridLinesVisible="false">
+                                            <xAxis>
+                                                <CategoryAxis side="BOTTOM" />
+                                            </xAxis>
+                                            <yAxis>
+                                                <NumberAxis side="LEFT" />
+                                            </yAxis>
+                                        </BarChart>
                                     </children>
                                 </VBox>
                             </children>


### PR DESCRIPTION
## Summary
- add DAO support for aggregating entrate/uscite into 3-day buckets for the current month
- display a dashboard bar chart with labeled 3-day ranges, padding missing buckets with zero values
- preserve existing color styling by applying bar colors after node creation and keep the chart scoped to the current month

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d7da8e2fc83339009e4691eef0a90)