### PR TITLE
Fix month labels orientation on yearly chart

### DIFF
--- a/src/it/unicas/project/template/address/view/SmoothAreaChart.java
+++ b/src/it/unicas/project/template/address/view/SmoothAreaChart.java
@@ -20,16 +20,26 @@ public class SmoothAreaChart<X, Y> extends AreaChart<X, Y> {
     // --- COSTRUTTORE AGGIUNTO PER FXML ---
     public SmoothAreaChart() {
         this((Axis<X>) new CategoryAxis(), (Axis<Y>) new NumberAxis());
+        configureXAxis();
     }
 
     public SmoothAreaChart(Axis<X> xAxis, Axis<Y> yAxis) {
         super(xAxis, yAxis);
+        configureXAxis();
         configureYAxis();
     }
 
     public SmoothAreaChart(Axis<X> xAxis, Axis<Y> yAxis, ObservableList<Series<X, Y>> data) {
         super(xAxis, yAxis, data);
+        configureXAxis();
         configureYAxis();
+    }
+
+    private void configureXAxis() {
+        if (getXAxis() instanceof CategoryAxis) {
+            CategoryAxis xAxis = (CategoryAxis) getXAxis();
+            xAxis.setTickLabelRotation(0);
+        }
     }
 
     private void configureYAxis() {


### PR DESCRIPTION
Added configureXAxis() method to SmoothAreaChart that sets tick label rotation to 0 degrees, ensuring month labels remain horizontal in both 6-month and 12-month views.