### PR TITLE
Add scroll support to movements and reports views

### DIFF
--- a/src/it/unicas/project/template/address/view/Movimenti.fxml
+++ b/src/it/unicas/project/template/address/view/Movimenti.fxml
@@ -9,141 +9,145 @@
 
 <AnchorPane prefHeight="700.0" prefWidth="1100.0" style="-fx-background-color: #f8fafc;" xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="it.unicas.project.template.address.view.MovimentiController">
     <children>
-        <HBox spacing="20.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-            <padding>
-                <Insets bottom="20.0" left="20.0" right="20.0" top="20.0" />
-            </padding>
-            <children>
-
-                <!-- ============================================= -->
-                <!-- COLONNA SINISTRA: INSERIMENTO (Panel Form) -->
-                <!-- ============================================= -->
-                <VBox prefWidth="350.0" spacing="15.0" style="-fx-background-color: white; -fx-background-radius: 12; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.05), 10, 0, 0, 4);">
+        <ScrollPane fitToHeight="true" fitToWidth="true" hbarPolicy="NEVER" vbarPolicy="AS_NEEDED" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+            <content>
+                <HBox spacing="20.0">
                     <padding>
-                        <Insets bottom="25.0" left="25.0" right="25.0" top="25.0" />
+                        <Insets bottom="20.0" left="20.0" right="20.0" top="20.0" />
                     </padding>
                     <children>
-                        <Label text="Nuova Transazione" textFill="#1e293b">
-                            <font>
-                                <Font name="System Bold" size="20.0" />
-                            </font>
-                        </Label>
-                        <Separator />
 
-                        <!-- IMPORTO (Grande) -->
-                        <VBox spacing="5.0">
+                        <!-- ============================================= -->
+                        <!-- COLONNA SINISTRA: INSERIMENTO (Panel Form) -->
+                        <!-- ============================================= -->
+                        <VBox prefWidth="350.0" spacing="15.0" style="-fx-background-color: white; -fx-background-radius: 12; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.05), 10, 0, 0, 4);">
+                            <padding>
+                                <Insets bottom="25.0" left="25.0" right="25.0" top="25.0" />
+                            </padding>
                             <children>
-                                <Label text="Importo (€)" textFill="#64748b" />
-                                <TextField fx:id="amountField" promptText="0.00" style="-fx-background-color: #f1f5f9; -fx-background-radius: 8; -fx-font-size: 18px; -fx-font-weight: bold; -fx-alignment: CENTER-RIGHT;" />
-                            </children>
-                        </VBox>
+                                <Label text="Nuova Transazione" textFill="#1e293b">
+                                    <font>
+                                        <Font name="System Bold" size="20.0" />
+                                    </font>
+                                </Label>
+                                <Separator />
 
-                        <!-- TIPO E DATA -->
-                        <HBox spacing="10.0">
-                            <children>
-                                <VBox spacing="5.0" HBox.hgrow="ALWAYS">
+                                <!-- IMPORTO (Grande) -->
+                                <VBox spacing="5.0">
                                     <children>
-                                        <Label text="Tipo" textFill="#64748b" />
-                                        <ComboBox fx:id="typeField" maxWidth="1.7976931348623157E308" style="-fx-background-color: #f1f5f9; -fx-background-radius: 8;" />
+                                        <Label text="Importo (€)" textFill="#64748b" />
+                                        <TextField fx:id="amountField" promptText="0.00" style="-fx-background-color: #f1f5f9; -fx-background-radius: 8; -fx-font-size: 18px; -fx-font-weight: bold; -fx-alignment: CENTER-RIGHT;" />
                                     </children>
                                 </VBox>
-                                <VBox spacing="5.0" HBox.hgrow="ALWAYS">
+
+                                <!-- TIPO E DATA -->
+                                <HBox spacing="10.0">
                                     <children>
-                                        <Label text="Data" textFill="#64748b" />
-                                        <DatePicker fx:id="dateField" maxHeight="26.0" maxWidth="1.7976931348623157E308" prefHeight="26.0" prefWidth="130.0" style="-fx-background-color: transparent;" />
+                                        <VBox spacing="5.0" HBox.hgrow="ALWAYS">
+                                            <children>
+                                                <Label text="Tipo" textFill="#64748b" />
+                                                <ComboBox fx:id="typeField" maxWidth="1.7976931348623157E308" style="-fx-background-color: #f1f5f9; -fx-background-radius: 8;" />
+                                            </children>
+                                        </VBox>
+                                        <VBox spacing="5.0" HBox.hgrow="ALWAYS">
+                                            <children>
+                                                <Label text="Data" textFill="#64748b" />
+                                                <DatePicker fx:id="dateField" maxHeight="26.0" maxWidth="1.7976931348623157E308" prefHeight="26.0" prefWidth="130.0" style="-fx-background-color: transparent;" />
+                                            </children>
+                                        </VBox>
+                                    </children>
+                                </HBox>
+
+                                <!-- CATEGORIA (Menu a tendina) -->
+                                <VBox spacing="5.0">
+                                    <children>
+                                        <Label text="Categoria" textFill="#64748b" />
+                                        <ComboBox fx:id="categoryField" maxWidth="1.7976931348623157E308" promptText="Seleziona..." style="-fx-background-color: #f1f5f9; -fx-background-radius: 8;" />
                                     </children>
                                 </VBox>
-                            </children>
-                        </HBox>
 
-                        <!-- CATEGORIA (Menu a tendina) -->
-                        <VBox spacing="5.0">
-                            <children>
-                                <Label text="Categoria" textFill="#64748b" />
-                                <ComboBox fx:id="categoryField" maxWidth="1.7976931348623157E308" promptText="Seleziona..." style="-fx-background-color: #f1f5f9; -fx-background-radius: 8;" />
+                                <!-- METODO PAGAMENTO (Menu a tendina) -->
+                                <VBox spacing="5.0">
+                                    <children>
+                                        <Label text="Metodo Pagamento (Opzionale)" textFill="#64748b" />
+                                        <ComboBox fx:id="methodField" editable="true" maxWidth="1.7976931348623157E308" promptText="Seleziona..." style="-fx-background-color: #f1f5f9; -fx-background-radius: 8;" />
+                                    </children>
+                                </VBox>
+
+                                <!-- DESCRIZIONE (Area di testo limitata) -->
+                                <VBox spacing="5.0">
+                                    <children>
+                                        <HBox alignment="CENTER_LEFT">
+                                            <children>
+                                                <Label text="Titolo (Opzionale)" textFill="#64748b" />
+                                                <Region HBox.hgrow="ALWAYS" />
+                                                <Label fx:id="charCountLabel" text="0/100" textFill="#cbd5e1">
+                                                    <font>
+                                                        <Font size="10.0" />
+                                                    </font>
+                                                </Label>
+                                            </children>
+                                        </HBox>
+                                        <!-- TextArea per scrivere di più, ma piccola -->
+                                        <TextArea fx:id="descArea" prefHeight="80.0" promptText="Note aggiuntive..." style="-fx-background-color: transparent; -fx-border-color: #e2e8f0; -fx-border-radius: 8; -fx-background-radius: 8;" wrapText="true" />
+                                    </children>
+                                </VBox>
+
+                                <Region VBox.vgrow="ALWAYS" />
+
+                                <!-- BOTTONE SALVA -->
+                                <Button defaultButton="true" maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#handleNewTransaction" prefHeight="45.0" style="-fx-background-color: #3b82f6; -fx-text-fill: white; -fx-background-radius: 8; -fx-cursor: hand;" text="REGISTRA MOVIMENTO">
+                                    <font>
+                                        <Font name="System Bold" size="14.0" />
+                                    </font>
+                                    <effect>
+                                        <DropShadow height="15.0" radius="7.0" width="15.0">
+                                            <color>
+                                                <Color red="0.23" green="0.5" blue="0.96" opacity="0.3" />
+                                            </color>
+                                        </DropShadow>
+                                    </effect>
+                                </Button>
+
                             </children>
                         </VBox>
 
-                        <!-- METODO PAGAMENTO (Menu a tendina) -->
-                        <VBox spacing="5.0">
-                            <children>
-                                <Label text="Metodo Pagamento (Opzionale)" textFill="#64748b" />
-                                <ComboBox fx:id="methodField" editable="true" maxWidth="1.7976931348623157E308" promptText="Seleziona..." style="-fx-background-color: #f1f5f9; -fx-background-radius: 8;" />
-                            </children>
-                        </VBox>
-
-                        <!-- DESCRIZIONE (Area di testo limitata) -->
-                        <VBox spacing="5.0">
+                        <!-- ============================================= -->
+                        <!-- COLONNA DESTRA: TABELLA DATI -->
+                        <!-- ============================================= -->
+                        <VBox spacing="10.0" HBox.hgrow="ALWAYS">
                             <children>
                                 <HBox alignment="CENTER_LEFT">
                                     <children>
-                                        <Label text="Titolo (Opzionale)" textFill="#64748b" />
-                                        <Region HBox.hgrow="ALWAYS" />
-                                        <Label fx:id="charCountLabel" text="0/100" textFill="#cbd5e1">
+                                        <Label text="Storico Transazioni" textFill="#1e293b">
                                             <font>
-                                                <Font size="10.0" />
+                                                <Font name="System Bold" size="18.0" />
                                             </font>
                                         </Label>
+                                        <Region HBox.hgrow="ALWAYS" />
+                                        <Button mnemonicParsing="false" onAction="#handleDeleteTransaction" style="-fx-background-color: white; -fx-border-color: #ef4444; -fx-text-fill: #ef4444; -fx-border-radius: 6; -fx-cursor: hand;" text="Elimina Selezionati" />
                                     </children>
                                 </HBox>
-                                <!-- TextArea per scrivere di più, ma piccola -->
-                                <TextArea fx:id="descArea" prefHeight="80.0" promptText="Note aggiuntive..." style="-fx-background-color: transparent; -fx-border-color: #e2e8f0; -fx-border-radius: 8; -fx-background-radius: 8;" wrapText="true" />
+
+                                <TableView fx:id="transactionTable" prefHeight="622.0" prefWidth="494.0" style="-fx-background-color: white; -fx-background-radius: 8; -fx-border-radius: 8; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.05), 5, 0, 0, 2);" VBox.vgrow="ALWAYS">
+                                    <columns>
+                                        <TableColumn fx:id="dateColumn" prefWidth="100.0" text="DATA" />
+                                        <TableColumn fx:id="typeColumn" prefWidth="90.0" style="-fx-alignment: CENTER;" text="TIPO" />
+                                        <TableColumn fx:id="categoryColumn" prefWidth="140.0" text="CATEGORIA" />
+                                        <TableColumn fx:id="titleColumn" prefWidth="250.0" text="TITOLO" />
+                                        <TableColumn fx:id="paymentMethodColumn" prefWidth="130.0" text="METODO" />
+                                        <TableColumn fx:id="amountColumn" prefWidth="120.0" style="-fx-alignment: CENTER-RIGHT;" text="IMPORTO" />
+                                    </columns>
+                                    <columnResizePolicy>
+                                        <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
+                                    </columnResizePolicy>
+                                </TableView>
                             </children>
                         </VBox>
 
-                        <Region VBox.vgrow="ALWAYS" />
-
-                        <!-- BOTTONE SALVA -->
-                        <Button defaultButton="true" maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#handleNewTransaction" prefHeight="45.0" style="-fx-background-color: #3b82f6; -fx-text-fill: white; -fx-background-radius: 8; -fx-cursor: hand;" text="REGISTRA MOVIMENTO">
-                            <font>
-                                <Font name="System Bold" size="14.0" />
-                            </font>
-                            <effect>
-                                <DropShadow height="15.0" radius="7.0" width="15.0">
-                                    <color>
-                                        <Color red="0.23" green="0.5" blue="0.96" opacity="0.3" />
-                                    </color>
-                                </DropShadow>
-                            </effect>
-                        </Button>
-
                     </children>
-                </VBox>
-
-                <!-- ============================================= -->
-                <!-- COLONNA DESTRA: TABELLA DATI -->
-                <!-- ============================================= -->
-                <VBox spacing="10.0" HBox.hgrow="ALWAYS">
-                    <children>
-                        <HBox alignment="CENTER_LEFT">
-                            <children>
-                                <Label text="Storico Transazioni" textFill="#1e293b">
-                                    <font>
-                                        <Font name="System Bold" size="18.0" />
-                                    </font>
-                                </Label>
-                                <Region HBox.hgrow="ALWAYS" />
-                                <Button mnemonicParsing="false" onAction="#handleDeleteTransaction" style="-fx-background-color: white; -fx-border-color: #ef4444; -fx-text-fill: #ef4444; -fx-border-radius: 6; -fx-cursor: hand;" text="Elimina Selezionati" />
-                            </children>
-                        </HBox>
-
-                        <TableView fx:id="transactionTable" prefHeight="622.0" prefWidth="494.0" style="-fx-background-color: white; -fx-background-radius: 8; -fx-border-radius: 8; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.05), 5, 0, 0, 2);" VBox.vgrow="ALWAYS">
-                            <columns>
-                                <TableColumn fx:id="dateColumn" prefWidth="100.0" text="DATA" />
-                                <TableColumn fx:id="typeColumn" prefWidth="90.0" style="-fx-alignment: CENTER;" text="TIPO" />
-                                <TableColumn fx:id="categoryColumn" prefWidth="140.0" text="CATEGORIA" />
-                                <TableColumn fx:id="titleColumn" prefWidth="250.0" text="TITOLO" />
-                                <TableColumn fx:id="paymentMethodColumn" prefWidth="130.0" text="METODO" />
-                                <TableColumn fx:id="amountColumn" prefWidth="120.0" style="-fx-alignment: CENTER-RIGHT;" text="IMPORTO" />
-                            </columns>
-                            <columnResizePolicy>
-                                <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
-                            </columnResizePolicy>
-                        </TableView>
-                    </children>
-                </VBox>
-
-            </children>
-        </HBox>
+                </HBox>
+            </content>
+        </ScrollPane>
     </children>
 </AnchorPane>

--- a/src/it/unicas/project/template/address/view/Report.fxml
+++ b/src/it/unicas/project/template/address/view/Report.fxml
@@ -9,70 +9,256 @@
 
 <AnchorPane minHeight="600.0" minWidth="900.0" style="-fx-background-color: #f8fafc;" xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="it.unicas.project.template.address.view.ReportController">
     <children>
-        <VBox spacing="20.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-            <padding>
-                <Insets bottom="30.0" left="30.0" right="30.0" top="30.0" />
-            </padding>
-            <children>
-
-                <!-- TITOLO -->
-                <Label text="Report" textFill="#1e293b">
-                    <font>
-                        <Font name="System Bold" size="28.0" />
-                    </font>
-                </Label>
-
-                <!-- CONTENUTO PRINCIPALE - GridPane che si espande -->
-                <GridPane hgap="25.0" vgap="25.0" VBox.vgrow="ALWAYS">
-                    <columnConstraints>
-                        <!-- Colonna sinistra: 50% -->
-                        <ColumnConstraints hgrow="ALWAYS" percentWidth="50.0" />
-                        <!-- Colonna destra: 50% -->
-                        <ColumnConstraints hgrow="ALWAYS" percentWidth="50.0" />
-                    </columnConstraints>
-                    <rowConstraints>
-                        <!-- Unica riga che si espande -->
-                        <RowConstraints vgrow="ALWAYS" minHeight="500.0" />
-                    </rowConstraints>
+        <ScrollPane fitToWidth="true" hbarPolicy="NEVER" vbarPolicy="AS_NEEDED" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+            <content>
+                <VBox spacing="20.0">
+                    <padding>
+                        <Insets bottom="30.0" left="30.0" right="30.0" top="30.0" />
+                    </padding>
                     <children>
 
-                        <!-- COLONNA SINISTRA: PIE CHART -->
-                        <AnchorPane style="-fx-background-color: white; -fx-background-radius: 12; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.05), 10, 0, 0, 5);" GridPane.columnIndex="0" GridPane.hgrow="ALWAYS" GridPane.vgrow="ALWAYS">
-                            <children>
-                                <VBox spacing="10.0" AnchorPane.bottomAnchor="15.0" AnchorPane.leftAnchor="15.0" AnchorPane.rightAnchor="15.0" AnchorPane.topAnchor="15.0">
-                                    <children>
-                                        <Label text="Distribuzione Spese" textFill="#1e293b">
-                                            <font>
-                                                <Font name="System Bold" size="18.0" />
-                                            </font>
-                                        </Label>
-                                        <PieChart fx:id="pieChart" legendSide="BOTTOM" style="-fx-background-color: transparent;" VBox.vgrow="ALWAYS" minHeight="400.0" />
-                                    </children>
-                                </VBox>
-                            </children>
-                        </AnchorPane>
+                        <!-- TITOLO -->
+                        <Label text="Report" textFill="#1e293b">
+                            <font>
+                                <Font name="System Bold" size="28.0" />
+                            </font>
+                        </Label>
 
-                        <!-- COLONNA DESTRA: LINE CHART (Andamento Finanziario) -->
-                        <VBox spacing="25.0" GridPane.columnIndex="1" GridPane.hgrow="ALWAYS" GridPane.vgrow="ALWAYS">
+                        <!-- CONTENUTO PRINCIPALE - GridPane che si espande -->
+                        <GridPane hgap="25.0" vgap="25.0" VBox.vgrow="ALWAYS">
+                            <columnConstraints>
+                                <!-- Colonna sinistra: 50% -->
+                                <ColumnConstraints hgrow="ALWAYS" percentWidth="50.0" />
+                                <!-- Colonna destra: 50% -->
+                                <ColumnConstraints hgrow="ALWAYS" percentWidth="50.0" />
+                            </columnConstraints>
+                            <rowConstraints>
+                                <!-- Unica riga che si espande -->
+                                <RowConstraints vgrow="ALWAYS" minHeight="500.0" />
+                            </rowConstraints>
                             <children>
 
-                                <!-- LINE CHART -->
-                                <AnchorPane style="-fx-background-color: white; -fx-background-radius: 12; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.05), 10, 0, 0, 5);" VBox.vgrow="ALWAYS">
+                                <!-- COLONNA SINISTRA: PIE CHART -->
+                                <AnchorPane style="-fx-background-color: white; -fx-background-radius: 12; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.05), 10, 0, 0, 5);" GridPane.columnIndex="0" GridPane.hgrow="ALWAYS" GridPane.vgrow="ALWAYS">
                                     <children>
                                         <VBox spacing="10.0" AnchorPane.bottomAnchor="15.0" AnchorPane.leftAnchor="15.0" AnchorPane.rightAnchor="15.0" AnchorPane.topAnchor="15.0">
                                             <children>
-                                                <HBox alignment="CENTER_LEFT" spacing="10.0">
+                                                <Label text="Distribuzione Spese" textFill="#1e293b">
+                                                    <font>
+                                                        <Font name="System Bold" size="18.0" />
+                                                    </font>
+                                                </Label>
+                                                <PieChart fx:id="pieChart" legendSide="BOTTOM" style="-fx-background-color: transparent;" VBox.vgrow="ALWAYS" minHeight="400.0" />
+                                            </children>
+                                        </VBox>
+                                    </children>
+                                </AnchorPane>
+
+                                <!-- COLONNA DESTRA: LINE CHART (Andamento Finanziario) -->
+                                <VBox spacing="25.0" GridPane.columnIndex="1" GridPane.hgrow="ALWAYS" GridPane.vgrow="ALWAYS">
+                                    <children>
+
+                                        <!-- LINE CHART -->
+                                        <AnchorPane style="-fx-background-color: white; -fx-background-radius: 12; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.05), 10, 0, 0, 5);" VBox.vgrow="ALWAYS">
+                                            <children>
+                                                <VBox spacing="10.0" AnchorPane.bottomAnchor="15.0" AnchorPane.leftAnchor="15.0" AnchorPane.rightAnchor="15.0" AnchorPane.topAnchor="15.0">
                                                     <children>
-                                                        <Label text="Andamento Finanziario" textFill="#1e293b">
-                                                            <font>
-                                                                <Font name="System Bold" size="18.0" />
-                                                            </font>
-                                                        </Label>
-                                                        <Region HBox.hgrow="ALWAYS" />
-                                                        <ComboBox fx:id="cmbRange" prefWidth="140.0" />
+                                                        <HBox alignment="CENTER_LEFT" spacing="10.0">
+                                                            <children>
+                                                                <Label text="Andamento Finanziario" textFill="#1e293b">
+                                                                    <font>
+                                                                        <Font name="System Bold" size="18.0" />
+                                                                    </font>
+                                                                </Label>
+                                                                <Region HBox.hgrow="ALWAYS" />
+                                                                <ComboBox fx:id="cmbRange" prefWidth="140.0" />
+                                                            </children>
+                                                        </HBox>
+                                                        <SmoothAreaChart fx:id="lineChartAndamento" animated="true" createSymbols="true" legendVisible="true" style="-fx-background-color: transparent;" VBox.vgrow="ALWAYS" minHeight="400.0" />
+                                                    </children>
+                                                </VBox>
+                                            </children>
+                                        </AnchorPane>
+
+                                    </children>
+                                </VBox>
+
+                            </children>
+                        </GridPane>
+
+                        <!-- SEZIONE PREVISIONI & ANALISI -->
+                        <VBox spacing="15.0">
+                            <children>
+                                <!-- Titolo Sezione -->
+                                <HBox alignment="CENTER_LEFT" spacing="10.0">
+                                    <children>
+                                        <Label text="📈" style="-fx-font-size: 24px;" />
+                                        <Label text="Previsioni &amp; Analisi" textFill="#1e293b">
+                                            <font>
+                                                <Font name="System Bold" size="24.0" />
+                                            </font>
+                                        </Label>
+                                    </children>
+                                </HBox>
+
+                                <!-- Card Principale Previsione -->
+                                <AnchorPane style="-fx-background-color: white; -fx-background-radius: 16; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.08), 15, 0, 0, 5);">
+                                    <children>
+                                        <VBox spacing="20.0" AnchorPane.bottomAnchor="25.0" AnchorPane.leftAnchor="25.0" AnchorPane.rightAnchor="25.0" AnchorPane.topAnchor="25.0">
+                                            <children>
+
+                                                <!-- Header con Titolo e Saldo Stimato -->
+                                                <HBox alignment="CENTER_LEFT">
+                                                    <children>
+                                                        <!-- Titolo -->
+                                                        <VBox spacing="5.0" HBox.hgrow="ALWAYS">
+                                                            <children>
+                                                                <Label text="Proiezione Fine Mese" textFill="#475569">
+                                                                    <font>
+                                                                        <Font name="System Bold" size="16.0" />
+                                                                    </font>
+                                                                </Label>
+                                                                <Label fx:id="lblPeriodoCalcolo" text="Calcolata sui movimenti reali dal giorno 1 al 22" textFill="#94a3b8">
+                                                                    <font>
+                                                                        <Font size="13.0" />
+                                                                    </font>
+                                                                </Label>
+                                                            </children>
+                                                        </VBox>
+
+                                                        <!-- Saldo Stimato -->
+                                                        <VBox alignment="CENTER_RIGHT" spacing="3.0">
+                                                            <children>
+                                                                <Label text="SALDO STIMATO" textFill="#64748b">
+                                                                    <font>
+                                                                        <Font name="System Bold" size="11.0" />
+                                                                    </font>
+                                                                </Label>
+                                                                <Label fx:id="lblSaldoStimato" text="€ 850.00" textFill="#10b981">
+                                                                    <font>
+                                                                        <Font name="System Bold" size="32.0" />
+                                                                    </font>
+                                                                </Label>
+                                                            </children>
+                                                        </VBox>
                                                     </children>
                                                 </HBox>
-                                                <SmoothAreaChart fx:id="lineChartAndamento" animated="true" createSymbols="true" legendVisible="true" style="-fx-background-color: transparent;" VBox.vgrow="ALWAYS" minHeight="400.0" />
+
+                                                <!-- Status Box -->
+                                                <AnchorPane fx:id="paneStatus" style="-fx-background-color: #d1fae5; -fx-background-radius: 12; -fx-border-color: #10b981; -fx-border-radius: 12; -fx-border-width: 2;">
+                                                    <children>
+                                                        <HBox alignment="CENTER_LEFT" spacing="15.0" AnchorPane.bottomAnchor="15.0" AnchorPane.leftAnchor="20.0" AnchorPane.rightAnchor="20.0" AnchorPane.topAnchor="15.0">
+                                                            <children>
+                                                                <Label fx:id="lblStatusIcon" text="📈" style="-fx-font-size: 28px;" />
+                                                                <VBox spacing="3.0" HBox.hgrow="ALWAYS">
+                                                                    <children>
+                                                                        <Label fx:id="lblStatusTitolo" text="Situazione Stabile" textFill="#065f46">
+                                                                            <font>
+                                                                                <Font name="System Bold" size="18.0" />
+                                                                            </font>
+                                                                        </Label>
+                                                                        <Label fx:id="lblStatusMessaggio" text="Previsione positiva. Mantenendo questo trend, chiuderai il mese in attivo." textFill="#047857" wrapText="true">
+                                                                            <font>
+                                                                                <Font size="14.0" />
+                                                                            </font>
+                                                                        </Label>
+                                                                    </children>
+                                                                </VBox>
+                                                            </children>
+                                                        </HBox>
+                                                    </children>
+                                                </AnchorPane>
+
+                                                <!-- Dettagli Calcolo -->
+                                                <GridPane hgap="30.0" vgap="15.0">
+                                                    <columnConstraints>
+                                                        <ColumnConstraints hgrow="SOMETIMES" percentWidth="33.0" />
+                                                        <ColumnConstraints hgrow="SOMETIMES" percentWidth="33.0" />
+                                                        <ColumnConstraints hgrow="SOMETIMES" percentWidth="34.0" />
+                                                    </columnConstraints>
+                                                    <rowConstraints>
+                                                        <RowConstraints />
+                                                    </rowConstraints>
+                                                    <children>
+
+                                                        <!-- Giorni Rimanenti -->
+                                                        <HBox alignment="CENTER_LEFT" spacing="10.0" GridPane.columnIndex="0">
+                                                            <children>
+                                                                <Label text="📅" style="-fx-font-size: 20px;" />
+                                                                <VBox spacing="3.0">
+                                                                    <children>
+                                                                        <Label text="Giorni rimanenti" textFill="#64748b">
+                                                                            <font>
+                                                                                <Font size="13.0" />
+                                                                            </font>
+                                                                        </Label>
+                                                                        <Label fx:id="lblGiorniRimanenti" text="8 gg" textFill="#1e293b">
+                                                                            <font>
+                                                                                <Font name="System Bold" size="20.0" />
+                                                                            </font>
+                                                                        </Label>
+                                                                    </children>
+                                                                </VBox>
+                                                            </children>
+                                                        </HBox>
+
+                                                        <!-- Media Spese Giornaliera -->
+                                                        <HBox alignment="CENTER_LEFT" spacing="10.0" GridPane.columnIndex="1">
+                                                            <children>
+                                                                <Label text="💰" style="-fx-font-size: 20px;" />
+                                                                <VBox spacing="3.0">
+                                                                    <children>
+                                                                        <Label text="Media spese giornaliera" textFill="#64748b">
+                                                                            <font>
+                                                                                <Font size="13.0" />
+                                                                            </font>
+                                                                        </Label>
+                                                                        <Label fx:id="lblMediaSpeseGiornaliera" text="€ 55.00" textFill="#1e293b">
+                                                                            <font>
+                                                                                <Font name="System Bold" size="20.0" />
+                                                                            </font>
+                                                                        </Label>
+                                                                    </children>
+                                                                </VBox>
+                                                            </children>
+                                                        </HBox>
+
+                                                        <!-- Spese Proiettate Totali -->
+                                                        <HBox alignment="CENTER_LEFT" spacing="10.0" GridPane.columnIndex="2">
+                                                            <children>
+                                                                <Label text="💸" style="-fx-font-size: 20px;" />
+                                                                <VBox spacing="3.0">
+                                                                    <children>
+                                                                        <Label text="Spese Proiettate Totali" textFill="#64748b">
+                                                                            <font>
+                                                                                <Font size="13.0" />
+                                                                            </font>
+                                                                        </Label>
+                                                                        <Label fx:id="lblSpeseProiettateTotali" text="€ 1650.00" textFill="#ef4444">
+                                                                            <font>
+                                                                                <Font name="System Bold" size="20.0" />
+                                                                            </font>
+                                                                        </Label>
+                                                                    </children>
+                                                                </VBox>
+                                                            </children>
+                                                        </HBox>
+
+                                                    </children>
+                                                </GridPane>
+
+                                                <!-- Disclaimer -->
+                                                <HBox alignment="CENTER_LEFT" spacing="8.0" style="-fx-background-color: #f1f5f9; -fx-background-radius: 8; -fx-padding: 12;">
+                                                    <children>
+                                                        <Label text="ℹ️" style="-fx-font-size: 14px;" />
+                                                        <Label fx:id="lblDisclaimer" text="Il calcolo si basa sulla media ponderata delle spese effettuate nel mese corrente. Non include spese ricorrenti future non ancora contabilizzate." textFill="#475569" wrapText="true">
+                                                            <font>
+                                                                <Font size="12.0" />
+                                                            </font>
+                                                        </Label>
+                                                    </children>
+                                                </HBox>
+
                                             </children>
                                         </VBox>
                                     </children>
@@ -82,190 +268,8 @@
                         </VBox>
 
                     </children>
-                </GridPane>
-
-                <!-- SEZIONE PREVISIONI & ANALISI -->
-                <VBox spacing="15.0">
-                    <children>
-                        <!-- Titolo Sezione -->
-                        <HBox alignment="CENTER_LEFT" spacing="10.0">
-                            <children>
-                                <Label text="📈" style="-fx-font-size: 24px;" />
-                                <Label text="Previsioni &amp; Analisi" textFill="#1e293b">
-                                    <font>
-                                        <Font name="System Bold" size="24.0" />
-                                    </font>
-                                </Label>
-                            </children>
-                        </HBox>
-
-                        <!-- Card Principale Previsione -->
-                        <AnchorPane style="-fx-background-color: white; -fx-background-radius: 16; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.08), 15, 0, 0, 5);">
-                            <children>
-                                <VBox spacing="20.0" AnchorPane.bottomAnchor="25.0" AnchorPane.leftAnchor="25.0" AnchorPane.rightAnchor="25.0" AnchorPane.topAnchor="25.0">
-                                    <children>
-
-                                        <!-- Header con Titolo e Saldo Stimato -->
-                                        <HBox alignment="CENTER_LEFT">
-                                            <children>
-                                                <!-- Titolo -->
-                                                <VBox spacing="5.0" HBox.hgrow="ALWAYS">
-                                                    <children>
-                                                        <Label text="Proiezione Fine Mese" textFill="#475569">
-                                                            <font>
-                                                                <Font name="System Bold" size="16.0" />
-                                                            </font>
-                                                        </Label>
-                                                        <Label fx:id="lblPeriodoCalcolo" text="Calcolata sui movimenti reali dal giorno 1 al 22" textFill="#94a3b8">
-                                                            <font>
-                                                                <Font size="13.0" />
-                                                            </font>
-                                                        </Label>
-                                                    </children>
-                                                </VBox>
-
-                                                <!-- Saldo Stimato -->
-                                                <VBox alignment="CENTER_RIGHT" spacing="3.0">
-                                                    <children>
-                                                        <Label text="SALDO STIMATO" textFill="#64748b">
-                                                            <font>
-                                                                <Font name="System Bold" size="11.0" />
-                                                            </font>
-                                                        </Label>
-                                                        <Label fx:id="lblSaldoStimato" text="€ 850.00" textFill="#10b981">
-                                                            <font>
-                                                                <Font name="System Bold" size="32.0" />
-                                                            </font>
-                                                        </Label>
-                                                    </children>
-                                                </VBox>
-                                            </children>
-                                        </HBox>
-
-                                        <!-- Status Box -->
-                                        <AnchorPane fx:id="paneStatus" style="-fx-background-color: #d1fae5; -fx-background-radius: 12; -fx-border-color: #10b981; -fx-border-radius: 12; -fx-border-width: 2;">
-                                            <children>
-                                                <HBox alignment="CENTER_LEFT" spacing="15.0" AnchorPane.bottomAnchor="15.0" AnchorPane.leftAnchor="20.0" AnchorPane.rightAnchor="20.0" AnchorPane.topAnchor="15.0">
-                                                    <children>
-                                                        <Label fx:id="lblStatusIcon" text="📈" style="-fx-font-size: 28px;" />
-                                                        <VBox spacing="3.0" HBox.hgrow="ALWAYS">
-                                                            <children>
-                                                                <Label fx:id="lblStatusTitolo" text="Situazione Stabile" textFill="#065f46">
-                                                                    <font>
-                                                                        <Font name="System Bold" size="18.0" />
-                                                                    </font>
-                                                                </Label>
-                                                                <Label fx:id="lblStatusMessaggio" text="Previsione positiva. Mantenendo questo trend, chiuderai il mese in attivo." textFill="#047857" wrapText="true">
-                                                                    <font>
-                                                                        <Font size="14.0" />
-                                                                    </font>
-                                                                </Label>
-                                                            </children>
-                                                        </VBox>
-                                                    </children>
-                                                </HBox>
-                                            </children>
-                                        </AnchorPane>
-
-                                        <!-- Dettagli Calcolo -->
-                                        <GridPane hgap="30.0" vgap="15.0">
-                                            <columnConstraints>
-                                                <ColumnConstraints hgrow="SOMETIMES" percentWidth="33.0" />
-                                                <ColumnConstraints hgrow="SOMETIMES" percentWidth="33.0" />
-                                                <ColumnConstraints hgrow="SOMETIMES" percentWidth="34.0" />
-                                            </columnConstraints>
-                                            <rowConstraints>
-                                                <RowConstraints />
-                                            </rowConstraints>
-                                            <children>
-
-                                                <!-- Giorni Rimanenti -->
-                                                <HBox alignment="CENTER_LEFT" spacing="10.0" GridPane.columnIndex="0">
-                                                    <children>
-                                                        <Label text="📅" style="-fx-font-size: 20px;" />
-                                                        <VBox spacing="3.0">
-                                                            <children>
-                                                                <Label text="Giorni rimanenti" textFill="#64748b">
-                                                                    <font>
-                                                                        <Font size="13.0" />
-                                                                    </font>
-                                                                </Label>
-                                                                <Label fx:id="lblGiorniRimanenti" text="8 gg" textFill="#1e293b">
-                                                                    <font>
-                                                                        <Font name="System Bold" size="20.0" />
-                                                                    </font>
-                                                                </Label>
-                                                            </children>
-                                                        </VBox>
-                                                    </children>
-                                                </HBox>
-
-                                                <!-- Media Spese Giornaliera -->
-                                                <HBox alignment="CENTER_LEFT" spacing="10.0" GridPane.columnIndex="1">
-                                                    <children>
-                                                        <Label text="💰" style="-fx-font-size: 20px;" />
-                                                        <VBox spacing="3.0">
-                                                            <children>
-                                                                <Label text="Media spese giornaliera" textFill="#64748b">
-                                                                    <font>
-                                                                        <Font size="13.0" />
-                                                                    </font>
-                                                                </Label>
-                                                                <Label fx:id="lblMediaSpeseGiornaliera" text="€ 55.00" textFill="#1e293b">
-                                                                    <font>
-                                                                        <Font name="System Bold" size="20.0" />
-                                                                    </font>
-                                                                </Label>
-                                                            </children>
-                                                        </VBox>
-                                                    </children>
-                                                </HBox>
-
-                                                <!-- Spese Proiettate Totali -->
-                                                <HBox alignment="CENTER_LEFT" spacing="10.0" GridPane.columnIndex="2">
-                                                    <children>
-                                                        <Label text="💸" style="-fx-font-size: 20px;" />
-                                                        <VBox spacing="3.0">
-                                                            <children>
-                                                                <Label text="Spese Proiettate Totali" textFill="#64748b">
-                                                                    <font>
-                                                                        <Font size="13.0" />
-                                                                    </font>
-                                                                </Label>
-                                                                <Label fx:id="lblSpeseProiettateTotali" text="€ 1650.00" textFill="#ef4444">
-                                                                    <font>
-                                                                        <Font name="System Bold" size="20.0" />
-                                                                    </font>
-                                                                </Label>
-                                                            </children>
-                                                        </VBox>
-                                                    </children>
-                                                </HBox>
-
-                                            </children>
-                                        </GridPane>
-
-                                        <!-- Disclaimer -->
-                                        <HBox alignment="CENTER_LEFT" spacing="8.0" style="-fx-background-color: #f1f5f9; -fx-background-radius: 8; -fx-padding: 12;">
-                                            <children>
-                                                <Label text="ℹ️" style="-fx-font-size: 14px;" />
-                                                <Label fx:id="lblDisclaimer" text="Il calcolo si basa sulla media ponderata delle spese effettuate nel mese corrente. Non include spese ricorrenti future non ancora contabilizzate." textFill="#475569" wrapText="true">
-                                                    <font>
-                                                        <Font size="12.0" />
-                                                    </font>
-                                                </Label>
-                                            </children>
-                                        </HBox>
-
-                                    </children>
-                                </VBox>
-                            </children>
-                        </AnchorPane>
-
-                    </children>
                 </VBox>
-
-            </children>
-        </VBox>
+            </content>
+        </ScrollPane>
     </children>
 </AnchorPane>


### PR DESCRIPTION
## Summary
- wrap the Movimenti layout in a scroll pane so content remains accessible on smaller windows
- add a scrollable container to the Report screen to avoid truncated views

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ddba5f2388333a771855886ff013b)