### PR TITLE
Calculate month-end forecast in Report screen

### DIFF
--- a/src/it/unicas/project/template/address/view/Report.fxml
+++ b/src/it/unicas/project/template/address/view/Report.fxml
@@ -251,7 +251,7 @@
                                                 <HBox alignment="CENTER_LEFT" spacing="8.0" style="-fx-background-color: #f1f5f9; -fx-background-radius: 8; -fx-padding: 12;">
                                                     <children>
                                                         <Label text="ℹ️" style="-fx-font-size: 14px;" />
-                                                        <Label fx:id="lblDisclaimer" text="Il calcolo si basa sulla media ponderata delle spese effettuate nel mese corrente. Non include spese ricorrenti future non ancora contabilizzate." textFill="#475569" wrapText="true">
+                                                        <Label fx:id="lblDisclaimer" text="Il calcolo si basa sulla data più recente dei movimenti registrati e proietta sia entrate che uscite fino a fine mese. Non include movimenti ricorrenti futuri non ancora contabilizzati." textFill="#475569" wrapText="true">
                                                             <font>
                                                                 <Font size="12.0" />
                                                             </font>


### PR DESCRIPTION
…a entrate

- Usa la data più recente dei movimenti invece della data corrente del sistema
- Calcola giorni rimanenti basandosi sulla data dell'ultimo movimento
- Aggiunge proiezione delle entrate future (non solo uscite)
- Calcola saldo stimato come: entrate_proiettate - spese_proiettate
- Aggiorna UI per mostrare medie e proiezioni sia per entrate che uscite
- Aggiorna disclaimer per riflettere la nuova logica di calcolo

Risolve il problema dove con movimenti futuri (es. 27 dicembre) il calcolo usava la data corrente (2 dicembre) generando previsioni errate.