### PR TITLE
Update movements page calendar icon styling

### DIFF
--- a/bin/it/unicas/project/template/address/view/Movimenti.fxml
+++ b/bin/it/unicas/project/template/address/view/Movimenti.fxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import java.lang.String?>
 <?import javafx.geometry.*?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.effect.*?>
@@ -8,6 +9,9 @@
 <?import javafx.scene.text.*?>
 
 <AnchorPane prefHeight="700.0" prefWidth="1100.0" style="-fx-background-color: #f8fafc;" xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="it.unicas.project.template.address.view.MovimentiController">
+    <stylesheets>
+        <String fx:value="@css/custom-styles.css" />
+    </stylesheets>
     <children>
         <ScrollPane fitToHeight="true" fitToWidth="true" hbarPolicy="NEVER" vbarPolicy="AS_NEEDED" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
             <content>
@@ -52,7 +56,7 @@
                                         <VBox spacing="5.0" HBox.hgrow="ALWAYS">
                                             <children>
                                                 <Label text="Data" textFill="#64748b" />
-                                                <DatePicker fx:id="dateField" maxHeight="26.0" maxWidth="1.7976931348623157E308" prefHeight="26.0" prefWidth="130.0" style="-fx-background-color: transparent;" />
+                                                <DatePicker fx:id="dateField" maxWidth="1.7976931348623157E308" style="-fx-background-color: #f1f5f9; -fx-background-radius: 8;" />
                                             </children>
                                         </VBox>
                                     </children>
@@ -129,14 +133,14 @@
                                     </children>
                                 </HBox>
 
-                                <TableView fx:id="transactionTable" prefHeight="622.0" prefWidth="494.0" style="-fx-background-color: white; -fx-background-radius: 8; -fx-border-radius: 8; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.05), 5, 0, 0, 2);" VBox.vgrow="ALWAYS">
+                                <TableView fx:id="transactionTable" prefHeight="622.0" prefWidth="494.0" style="-fx-background-color: white; -fx-background-radius: 8; -fx-border-radius: 8; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.05), 5, 0, 0, 2);" styleClass="modern-table" VBox.vgrow="ALWAYS">
                                     <columns>
-                                        <TableColumn fx:id="dateColumn" prefWidth="100.0" text="DATA" />
-                                        <TableColumn fx:id="typeColumn" prefWidth="90.0" style="-fx-alignment: CENTER;" text="TIPO" />
-                                        <TableColumn fx:id="categoryColumn" prefWidth="140.0" text="CATEGORIA" />
-                                        <TableColumn fx:id="titleColumn" prefWidth="250.0" text="TITOLO" />
-                                        <TableColumn fx:id="paymentMethodColumn" prefWidth="130.0" text="METODO" />
-                                        <TableColumn fx:id="amountColumn" prefWidth="120.0" style="-fx-alignment: CENTER-RIGHT;" text="IMPORTO" />
+                                        <TableColumn fx:id="dateColumn" prefWidth="100.0" text="Data" />
+                                        <TableColumn fx:id="typeColumn" prefWidth="90.0" style="-fx-alignment: CENTER;" text="Tipo" />
+                                        <TableColumn fx:id="categoryColumn" prefWidth="140.0" text="Categoria" />
+                                        <TableColumn fx:id="titleColumn" prefWidth="250.0" text="Titolo" />
+                                        <TableColumn fx:id="paymentMethodColumn" prefWidth="130.0" text="Metodo" />
+                                        <TableColumn fx:id="amountColumn" prefWidth="120.0" style="-fx-alignment: CENTER-RIGHT;" text="Importo" />
                                     </columns>
                                     <columnResizePolicy>
                                         <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />

--- a/bin/it/unicas/project/template/address/view/css/custom-styles.css
+++ b/bin/it/unicas/project/template/address/view/css/custom-styles.css
@@ -1,0 +1,27 @@
+/* Custom styles for modern UI elements */
+
+/* Modern table header style */
+.modern-table > .column-header-background .column-header {
+    -fx-font-weight: 600;
+}
+
+.modern-table > .column-header-background .column-header .label {
+    -fx-text-fill: #64748b;
+    -fx-font-size: 11px;
+    -fx-font-weight: 600;
+    -fx-padding: 0 0.5em 0 0.5em;
+}
+
+/* Modern DatePicker style to match other form fields */
+.date-picker > .text-field {
+    -fx-background-color: #f1f5f9;
+    -fx-background-radius: 8;
+}
+
+.date-picker .arrow-button {
+    -fx-background-color: transparent;
+}
+
+.date-picker .arrow-button .arrow {
+    -fx-background-color: #64748b;
+}

--- a/src/it/unicas/project/template/address/view/Movimenti.fxml
+++ b/src/it/unicas/project/template/address/view/Movimenti.fxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import java.lang.String?>
 <?import javafx.geometry.*?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.effect.*?>
@@ -8,6 +9,9 @@
 <?import javafx.scene.text.*?>
 
 <AnchorPane prefHeight="700.0" prefWidth="1100.0" style="-fx-background-color: #f8fafc;" xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="it.unicas.project.template.address.view.MovimentiController">
+    <stylesheets>
+        <String fx:value="@css/custom-styles.css" />
+    </stylesheets>
     <children>
         <ScrollPane fitToHeight="true" fitToWidth="true" hbarPolicy="NEVER" vbarPolicy="AS_NEEDED" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
             <content>
@@ -52,7 +56,7 @@
                                         <VBox spacing="5.0" HBox.hgrow="ALWAYS">
                                             <children>
                                                 <Label text="Data" textFill="#64748b" />
-                                                <DatePicker fx:id="dateField" maxHeight="26.0" maxWidth="1.7976931348623157E308" prefHeight="26.0" prefWidth="130.0" style="-fx-background-color: transparent;" />
+                                                <DatePicker fx:id="dateField" maxWidth="1.7976931348623157E308" style="-fx-background-color: #f1f5f9; -fx-background-radius: 8;" />
                                             </children>
                                         </VBox>
                                     </children>
@@ -129,14 +133,14 @@
                                     </children>
                                 </HBox>
 
-                                <TableView fx:id="transactionTable" prefHeight="622.0" prefWidth="494.0" style="-fx-background-color: white; -fx-background-radius: 8; -fx-border-radius: 8; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.05), 5, 0, 0, 2);" VBox.vgrow="ALWAYS">
+                                <TableView fx:id="transactionTable" prefHeight="622.0" prefWidth="494.0" style="-fx-background-color: white; -fx-background-radius: 8; -fx-border-radius: 8; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.05), 5, 0, 0, 2);" styleClass="modern-table" VBox.vgrow="ALWAYS">
                                     <columns>
-                                        <TableColumn fx:id="dateColumn" prefWidth="100.0" text="DATA" />
-                                        <TableColumn fx:id="typeColumn" prefWidth="90.0" style="-fx-alignment: CENTER;" text="TIPO" />
-                                        <TableColumn fx:id="categoryColumn" prefWidth="140.0" text="CATEGORIA" />
-                                        <TableColumn fx:id="titleColumn" prefWidth="250.0" text="TITOLO" />
-                                        <TableColumn fx:id="paymentMethodColumn" prefWidth="130.0" text="METODO" />
-                                        <TableColumn fx:id="amountColumn" prefWidth="120.0" style="-fx-alignment: CENTER-RIGHT;" text="IMPORTO" />
+                                        <TableColumn fx:id="dateColumn" prefWidth="100.0" text="Data" />
+                                        <TableColumn fx:id="typeColumn" prefWidth="90.0" style="-fx-alignment: CENTER;" text="Tipo" />
+                                        <TableColumn fx:id="categoryColumn" prefWidth="140.0" text="Categoria" />
+                                        <TableColumn fx:id="titleColumn" prefWidth="250.0" text="Titolo" />
+                                        <TableColumn fx:id="paymentMethodColumn" prefWidth="130.0" text="Metodo" />
+                                        <TableColumn fx:id="amountColumn" prefWidth="120.0" style="-fx-alignment: CENTER-RIGHT;" text="Importo" />
                                     </columns>
                                     <columnResizePolicy>
                                         <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />

--- a/src/it/unicas/project/template/address/view/css/custom-styles.css
+++ b/src/it/unicas/project/template/address/view/css/custom-styles.css
@@ -1,0 +1,27 @@
+/* Custom styles for modern UI elements */
+
+/* Modern table header style */
+.modern-table > .column-header-background .column-header {
+    -fx-font-weight: 600;
+}
+
+.modern-table > .column-header-background .column-header .label {
+    -fx-text-fill: #64748b;
+    -fx-font-size: 11px;
+    -fx-font-weight: 600;
+    -fx-padding: 0 0.5em 0 0.5em;
+}
+
+/* Modern DatePicker style to match other form fields */
+.date-picker > .text-field {
+    -fx-background-color: #f1f5f9;
+    -fx-background-radius: 8;
+}
+
+.date-picker .arrow-button {
+    -fx-background-color: transparent;
+}
+
+.date-picker .arrow-button .arrow {
+    -fx-background-color: #64748b;
+}


### PR DESCRIPTION
- Uniformato il campo DatePicker con gli altri campi del form (sfondo #f1f5f9 e bordi arrotondati)
- Modernizzato le intestazioni della tabella: testo normale invece di maiuscolo, colore grigio tenue (#64748b)
- Creato file custom-styles.css per gli stili personalizzati che mantengono un aspetto moderno e minimal