### PR TITLE
Fix chart animations in dashboard and report

### DIFF
--- a/src/it/unicas/project/template/address/view/DashboardController.java
+++ b/src/it/unicas/project/template/address/view/DashboardController.java
@@ -12,6 +12,7 @@ import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.chart.BarChart;
+import javafx.scene.chart.NumberAxis;
 import javafx.scene.chart.XYChart;
 import javafx.scene.control.Label;
 import javafx.scene.control.ProgressBar;
@@ -219,6 +220,22 @@ public class DashboardController {
         }
 
         barChartAndamento.getData().addAll(seriesEntrate, seriesUscite);
+
+        // Fissa il range dell'asse Y per evitare scatti durante l'animazione
+        NumberAxis yAxis = (NumberAxis) barChartAndamento.getYAxis();
+        double maxValue = 0;
+        for (float v : entrateFinali) {
+            maxValue = Math.max(maxValue, v);
+        }
+        for (float v : usciteFinali) {
+            maxValue = Math.max(maxValue, v);
+        }
+
+        double padding = maxValue * 0.1;
+        yAxis.setAutoRanging(false);
+        yAxis.setLowerBound(0);
+        yAxis.setUpperBound(Math.max(10, maxValue + padding));
+        yAxis.setTickUnit(yAxis.getUpperBound() / 5);
 
         // Applica stili e tooltip dopo che i nodi sono stati creati
         Platform.runLater(() -> {

--- a/src/it/unicas/project/template/address/view/ReportController.java
+++ b/src/it/unicas/project/template/address/view/ReportController.java
@@ -12,6 +12,7 @@ import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.AnchorPane;
+import javafx.scene.layout.Region;
 import javafx.scene.shape.Rectangle;
 import javafx.util.Duration;
 import javafx.util.Pair;
@@ -223,16 +224,24 @@ public class ReportController {
         // Aspetta che il layout sia completo
         Platform.runLater(() -> {
             try {
-                // Crea un clip rettangolare
+                Region plotBackground = (Region) lineChartAndamento.lookup(".chart-plot-background");
+                if (plotBackground == null || plotBackground.getParent() == null) {
+                    return;
+                }
+
                 Rectangle clip = new Rectangle();
-                clip.setHeight(lineChartAndamento.getHeight() + 100);
-                clip.setWidth(0); // Inizia da 0
+                clip.widthProperty().set(0);
+                clip.heightProperty().bind(plotBackground.heightProperty());
+                clip.xProperty().bind(plotBackground.layoutXProperty());
+                clip.yProperty().bind(plotBackground.layoutYProperty());
 
-                lineChartAndamento.setClip(clip);
+                plotBackground.getParent().setClip(clip);
 
-                double targetWidth = lineChartAndamento.getWidth() + 100;
+                double targetWidth = plotBackground.getWidth();
+                if (targetWidth <= 0) {
+                    targetWidth = plotBackground.getBoundsInParent().getWidth();
+                }
 
-                // Animazione del clip
                 Timeline timeline = new Timeline();
 
                 KeyValue kv = new KeyValue(clip.widthProperty(), targetWidth, Interpolator.EASE_OUT);
@@ -240,10 +249,7 @@ public class ReportController {
 
                 timeline.getKeyFrames().add(kf);
 
-                timeline.setOnFinished(e -> {
-                    // Rimuovi il clip alla fine
-                    lineChartAndamento.setClip(null);
-                });
+                timeline.setOnFinished(e -> plotBackground.getParent().setClip(null));
 
                 // Piccolo delay per assicurarsi che il grafico sia renderizzato
                 PauseTransition pause = new PauseTransition(Duration.millis(100));


### PR DESCRIPTION
## Summary
- stabilize dashboard bar chart animation by fixing Y-axis bounds before animating bars
- confine report line chart reveal animation to plot area so axes and labels stay visible

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692eecdf0ec083339e192290293b213b)