### PR TITLE
Add lightweight tests and user manual

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,20 @@
+# Esecuzione dei test
+
+Il progetto non utilizza un sistema di build preconfigurato, quindi è stato incluso un runner minimale basato su un'annotazione `@Test` compatibile con JUnit 5 per eseguire i casi di test senza dipendenze esterne.
+
+## Compilazione
+```bash
+javac -d out/test-classes \
+  src/test/java/org/junit/jupiter/api/*.java \
+  src/it/unicas/project/template/address/util/BudgetNotificationPreferences.java \
+  src/it/unicas/project/template/address/util/DateUtil.java \
+  src/test/java/it/unicas/project/template/address/util/*.java \
+  src/test/java/TestRunner.java
+```
+
+## Esecuzione
+```bash
+java -cp out/test-classes TestRunner
+```
+
+Il runner stampa l'esito di ciascun test e restituisce un codice di uscita diverso da zero in caso di fallimento.

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -1,0 +1,32 @@
+# Manuale Utente - Personal Finance Desktop Application
+
+## Avvio dell'applicazione
+1. Avvia Java 21 o superiore e JavaFX installato nel sistema.
+2. Assicurati che il database MySQL sia raggiungibile e che il file `PersonalFinanceDB.sql` sia importato.
+3. Esegui la classe `it.unicas.project.template.address.MainApp` dall'IDE oppure con Ant usando `build/build.xml`.
+
+## Autenticazione
+- **Login**: inserisci username e password registrati. L'app verifica le credenziali tramite `UserDAO`.
+- **Registrazione**: crea un nuovo account usando il pulsante di registrazione.
+
+## Gestione Movimenti
+- **Creazione**: premi "Nuovo" per aggiungere un movimento con titolo, importo, data e metodo di pagamento.
+- **Modifica**: seleziona un movimento esistente e usa "Modifica".
+- **Eliminazione**: seleziona un elemento e premi "Elimina".
+- I campi sono validati e i dati vengono salvati nel database.
+
+## Gestione Budget
+- Imposta un limite mensile per ogni categoria.
+- La colonna "Speso" mostra l'importo consumato; "Rimanente" calcola il saldo residuo.
+- Le notifiche di superamento budget sono gestite tramite `BudgetNotificationHelper` e `BudgetNotificationPreferences`.
+- Puoi disabilitare le notifiche per una categoria direttamente dal popup di allerta.
+
+## Suggerimenti di utilizzo
+- Aggiorna i movimenti con regolarità per tenere sincronizzati i calcoli del budget.
+- Esporta periodicamente il database per avere un backup dei dati personali.
+- Usa categorie coerenti: semplifica l'analisi delle spese ricorrenti.
+
+## Risoluzione problemi comuni
+- **La finestra non si apre**: verifica di aver configurato correttamente il path di JavaFX nel run configuration.
+- **Credenziali rifiutate**: controlla la connessione al database e che la tabella utenti contenga l'account.
+- **Notifiche ripetute**: se hai riabilitato una categoria, assicurati di non avere movimenti che superano di nuovo il limite.

--- a/docs/user_manual.pdf
+++ b/docs/user_manual.pdf
@@ -1,0 +1,52 @@
+%PDF-1.4
+%
+1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj
+2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj
+3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >> endobj
+5 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj
+4 0 obj << /Length 2892 >> stream
+BT /F1 12 Tf 50 760 Td (# Manuale Utente - Personal Finance Desktop Application) Tj ET
+BT /F1 12 Tf 50 744 Td () Tj ET
+BT /F1 12 Tf 50 728 Td (## Avvio dell'applicazione) Tj ET
+BT /F1 12 Tf 50 712 Td (1. Avvia Java 21 o superiore e JavaFX installato nel sistema.) Tj ET
+BT /F1 12 Tf 50 696 Td (2. Assicurati che il database MySQL sia raggiungibile e che il file `PersonalFinanceDB.sql` sia importato.) Tj ET
+BT /F1 12 Tf 50 680 Td (3. Esegui la classe `it.unicas.project.template.address.MainApp` dall'IDE oppure con Ant usando `build/build.xml`.) Tj ET
+BT /F1 12 Tf 50 664 Td () Tj ET
+BT /F1 12 Tf 50 648 Td (## Autenticazione) Tj ET
+BT /F1 12 Tf 50 632 Td (- **Login**: inserisci username e password registrati. L'app verifica le credenziali tramite `UserDAO`.) Tj ET
+BT /F1 12 Tf 50 616 Td (- **Registrazione**: crea un nuovo account usando il pulsante di registrazione.) Tj ET
+BT /F1 12 Tf 50 600 Td () Tj ET
+BT /F1 12 Tf 50 584 Td (## Gestione Movimenti) Tj ET
+BT /F1 12 Tf 50 568 Td (- **Creazione**: premi "Nuovo" per aggiungere un movimento con titolo, importo, data e metodo di pagamento.) Tj ET
+BT /F1 12 Tf 50 552 Td (- **Modifica**: seleziona un movimento esistente e usa "Modifica".) Tj ET
+BT /F1 12 Tf 50 536 Td (- **Eliminazione**: seleziona un elemento e premi "Elimina".) Tj ET
+BT /F1 12 Tf 50 520 Td (- I campi sono validati e i dati vengono salvati nel database.) Tj ET
+BT /F1 12 Tf 50 504 Td () Tj ET
+BT /F1 12 Tf 50 488 Td (## Gestione Budget) Tj ET
+BT /F1 12 Tf 50 472 Td (- Imposta un limite mensile per ogni categoria.) Tj ET
+BT /F1 12 Tf 50 456 Td (- La colonna "Speso" mostra l'importo consumato; "Rimanente" calcola il saldo residuo.) Tj ET
+BT /F1 12 Tf 50 440 Td (- Le notifiche di superamento budget sono gestite tramite `BudgetNotificationHelper` e `BudgetNotificationPreferences`.) Tj ET
+BT /F1 12 Tf 50 424 Td (- Puoi disabilitare le notifiche per una categoria direttamente dal popup di allerta.) Tj ET
+BT /F1 12 Tf 50 408 Td () Tj ET
+BT /F1 12 Tf 50 392 Td (## Suggerimenti di utilizzo) Tj ET
+BT /F1 12 Tf 50 376 Td (- Aggiorna i movimenti con regolarit per tenere sincronizzati i calcoli del budget.) Tj ET
+BT /F1 12 Tf 50 360 Td (- Esporta periodicamente il database per avere un backup dei dati personali.) Tj ET
+BT /F1 12 Tf 50 344 Td (- Usa categorie coerenti: semplifica l'analisi delle spese ricorrenti.) Tj ET
+BT /F1 12 Tf 50 328 Td () Tj ET
+BT /F1 12 Tf 50 312 Td (## Risoluzione problemi comuni) Tj ET
+BT /F1 12 Tf 50 296 Td (- **La finestra non si apre**: verifica di aver configurato correttamente il path di JavaFX nel run configuration.) Tj ET
+BT /F1 12 Tf 50 280 Td (- **Credenziali rifiutate**: controlla la connessione al database e che la tabella utenti contenga l'account.) Tj ET
+BT /F1 12 Tf 50 264 Td (- **Notifiche ripetute**: se hai riabilitato una categoria, assicurati di non avere movimenti che superano di nuovo il limite.) Tj ET
+endstream endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000247 00000 n 
+0000000317 00000 n 
+trailer << /Size 6 /Root 1 0 R >>
+startxref
+3260
+%%EOF

--- a/src/test/java/TestRunner.java
+++ b/src/test/java/TestRunner.java
@@ -1,0 +1,46 @@
+import it.unicas.project.template.address.util.BudgetNotificationPreferencesTest;
+import it.unicas.project.template.address.util.DateUtilTest;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+
+/**
+ * Semplice launcher per i test basato sull'annotazione @Test minimale.
+ */
+public class TestRunner {
+
+    public static void main(String[] args) throws Exception {
+        List<Class<?>> testClasses = List.of(
+            DateUtilTest.class,
+            BudgetNotificationPreferencesTest.class
+        );
+
+        int total = 0;
+        int failed = 0;
+
+        for (Class<?> testClass : testClasses) {
+            Object instance = testClass.getDeclaredConstructor().newInstance();
+            for (Method method : testClass.getDeclaredMethods()) {
+                if (method.isAnnotationPresent(Test.class)) {
+                    total++;
+                    try {
+                        method.setAccessible(true);
+                        method.invoke(instance);
+                        System.out.println("[PASS] " + testClass.getSimpleName() + ": " + method.getName());
+                    } catch (InvocationTargetException ex) {
+                        failed++;
+                        Throwable cause = ex.getTargetException();
+                        System.out.println("[FAIL] " + testClass.getSimpleName() + ": " + method.getName() + " -> " + cause.getMessage());
+                    }
+                }
+            }
+        }
+
+        System.out.println("Eseguiti " + total + " test. Falliti: " + failed);
+        if (failed > 0) {
+            System.exit(1);
+        }
+    }
+}

--- a/src/test/java/it/unicas/project/template/address/util/BudgetNotificationPreferencesTest.java
+++ b/src/test/java/it/unicas/project/template/address/util/BudgetNotificationPreferencesTest.java
@@ -1,0 +1,78 @@
+package it.unicas.project.template.address.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.YearMonth;
+import java.util.Map;
+import java.util.Set;
+
+public class BudgetNotificationPreferencesTest {
+
+    private BudgetNotificationPreferences newPreferencesWithTempFile() throws IOException {
+        Path tempFile = Files.createTempFile("prefs", ".txt");
+        Files.deleteIfExists(tempFile);
+        BudgetNotificationPreferences.resetForTesting(tempFile.toString());
+        return BudgetNotificationPreferences.getInstance();
+    }
+
+    @Test
+    public void canEnableAndDisableNotificationsPerCategory() throws IOException {
+        BudgetNotificationPreferences prefs = newPreferencesWithTempFile();
+
+        Assertions.assertFalse(prefs.isNotificationDisabled(3));
+        prefs.disableNotificationForCategory(3);
+        Assertions.assertTrue(prefs.isNotificationDisabled(3));
+
+        prefs.enableNotificationForCategory(3);
+        Assertions.assertFalse(prefs.isNotificationDisabled(3));
+    }
+
+    @Test
+    public void tracksNotificationsForCurrentMonth() throws IOException {
+        BudgetNotificationPreferences prefs = newPreferencesWithTempFile();
+
+        Assertions.assertFalse(prefs.wasAlreadyNotifiedThisMonth(7));
+        prefs.markAsNotified(7);
+        Assertions.assertTrue(prefs.wasAlreadyNotifiedThisMonth(7));
+
+        prefs.unmarkAsNotified(7);
+        Assertions.assertFalse(prefs.wasAlreadyNotifiedThisMonth(7));
+    }
+
+    @Test
+    public void cleansOldMonthsWhenLoadingPreferences() throws IOException {
+        Path tempFile = Files.createTempFile("prefs", ".txt");
+        String staleMonth = YearMonth.now().minusMonths(4).toString();
+        Files.write(tempFile, (
+                "notified." + staleMonth + "=2,4\n" +
+                "disabled=9\n").getBytes());
+
+        BudgetNotificationPreferences.resetForTesting(tempFile.toString());
+        BudgetNotificationPreferences prefs = BudgetNotificationPreferences.getInstance();
+
+        Map<String, Set<Integer>> snapshot = prefs.getNotifiedExceededCategoriesSnapshot();
+        Assertions.assertTrue(snapshot.isEmpty(), "I mesi più vecchi di 3 mesi devono essere rimossi");
+        Assertions.assertTrue(prefs.getDisabledCategoriesSnapshot().contains(9), "Le preferenze valide devono restare");
+    }
+
+    @Test
+    public void persistsChangesToDisk() throws IOException {
+        Path tempFile = Files.createTempFile("prefs", ".txt");
+        BudgetNotificationPreferences.resetForTesting(tempFile.toString());
+        BudgetNotificationPreferences prefs = BudgetNotificationPreferences.getInstance();
+
+        prefs.disableNotificationForCategory(12);
+        prefs.markAsNotified(5);
+
+        // Forza il reload dal file
+        BudgetNotificationPreferences.resetForTesting(tempFile.toString());
+        BudgetNotificationPreferences reloaded = BudgetNotificationPreferences.getInstance();
+
+        Assertions.assertTrue(reloaded.isNotificationDisabled(12));
+        Assertions.assertTrue(reloaded.wasAlreadyNotifiedThisMonth(5));
+    }
+}

--- a/src/test/java/it/unicas/project/template/address/util/DateUtilTest.java
+++ b/src/test/java/it/unicas/project/template/address/util/DateUtilTest.java
@@ -1,0 +1,39 @@
+package it.unicas.project.template.address.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+public class DateUtilTest {
+
+    @Test
+    public void formatsDateUsingExpectedPattern() {
+        LocalDate date = LocalDate.of(2024, 12, 25);
+        String formatted = DateUtil.format(date);
+        Assertions.assertEquals("25-12-2024", formatted, "Il formato dd-MM-yyyy deve essere rispettato");
+    }
+
+    @Test
+    public void formatReturnsNullWhenDateIsNull() {
+        Assertions.assertNull(DateUtil.format(null), "Una data nulla deve restituire null");
+    }
+
+    @Test
+    public void parsesValidDateString() {
+        LocalDate parsed = DateUtil.parse("01-03-2025");
+        Assertions.assertNotNull(parsed, "Una stringa valida deve essere convertita");
+        Assertions.assertEquals(LocalDate.of(2025, 3, 1), parsed, "La data risultante deve essere corretta");
+    }
+
+    @Test
+    public void parseReturnsNullForInvalidDate() {
+        Assertions.assertNull(DateUtil.parse("invalid"), "Una stringa non valida deve restituire null");
+    }
+
+    @Test
+    public void validDateDelegatesToParse() {
+        Assertions.assertTrue(DateUtil.validDate("10-10-2030"));
+        Assertions.assertFalse(DateUtil.validDate("32-99-2030"));
+    }
+}

--- a/src/test/java/org/junit/jupiter/api/Assertions.java
+++ b/src/test/java/org/junit/jupiter/api/Assertions.java
@@ -1,0 +1,61 @@
+package org.junit.jupiter.api;
+
+import java.util.Objects;
+
+/**
+ * Utility di asserzione minimale per non dipendere da JUnit esterno.
+ */
+public final class Assertions {
+
+    private Assertions() { }
+
+    public static void assertTrue(boolean condition, String message) {
+        if (!condition) {
+            throw new AssertionError(message);
+        }
+    }
+
+    public static void assertTrue(boolean condition) {
+        assertTrue(condition, "Expected condition to be true");
+    }
+
+    public static void assertFalse(boolean condition, String message) {
+        if (condition) {
+            throw new AssertionError(message);
+        }
+    }
+
+    public static void assertFalse(boolean condition) {
+        assertFalse(condition, "Expected condition to be false");
+    }
+
+    public static <T> void assertEquals(T expected, T actual, String message) {
+        if (!Objects.equals(expected, actual)) {
+            throw new AssertionError(message + " (expected: " + expected + ", actual: " + actual + ")");
+        }
+    }
+
+    public static <T> void assertEquals(T expected, T actual) {
+        assertEquals(expected, actual, "Values are not equal");
+    }
+
+    public static void assertNull(Object value, String message) {
+        if (value != null) {
+            throw new AssertionError(message + " (was: " + value + ")");
+        }
+    }
+
+    public static void assertNull(Object value) {
+        assertNull(value, "Expected value to be null");
+    }
+
+    public static void assertNotNull(Object value, String message) {
+        if (value == null) {
+            throw new AssertionError(message);
+        }
+    }
+
+    public static void assertNotNull(Object value) {
+        assertNotNull(value, "Expected value to be not null");
+    }
+}

--- a/src/test/java/org/junit/jupiter/api/Test.java
+++ b/src/test/java/org/junit/jupiter/api/Test.java
@@ -1,0 +1,14 @@
+package org.junit.jupiter.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Minimal replica dell'annotazione @Test per eseguire i test senza dipendenze esterne.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Test {
+}


### PR DESCRIPTION
## Summary
- add minimal JUnit-style test harness with coverage for DateUtil and budget notification preferences
- make budget notification preferences testable through configurable storage and snapshots
- document how to run tests and provide a PDF/Markdown user manual

## Testing
- java -cp out/test-classes TestRunner

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f11c84bbc833385e46e1e2236420f)