### PR TITLE
Add collapsible sidebar menu with icons

### DIFF
--- a/src/it/unicas/project/template/address/view/RootLayout.fxml
+++ b/src/it/unicas/project/template/address/view/RootLayout.fxml
@@ -6,7 +6,7 @@
 <?import javafx.scene.shape.*?>
 <?import javafx.scene.text.*?>
 
-<BorderPane prefHeight="600.0" prefWidth="1024.0" stylesheets="@css/primer-light.css" xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="it.unicas.project.template.address.view.RootLayoutController">
+<BorderPane prefHeight="600.0" prefWidth="1024.0" stylesheets="@css/primer-light.css,@css/collapsible-menu.css" xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="it.unicas.project.template.address.view.RootLayoutController">
 
     <top>
         <HBox alignment="CENTER_LEFT" prefHeight="80.0" prefWidth="200.0" spacing="20.0" style="-fx-background-color: #FFFFFF; -fx-border-color: #e2e8f0; -fx-border-width: 0 0 1 0;" BorderPane.alignment="CENTER">
@@ -92,71 +92,152 @@
     </top>
 
     <left>
-        <VBox prefHeight="520.0" prefWidth="220.0" spacing="10.0" style="-fx-background-color: #FFFFFF; -fx-border-color: #e2e8f0; -fx-border-width: 0 1 0 0;" BorderPane.alignment="CENTER">
+        <VBox fx:id="sidebar" prefHeight="520.0" prefWidth="220.0" spacing="5.0" style="-fx-background-color: #ffffff; -fx-border-color: #e2e8f0; -fx-border-width: 0 1 0 0;" BorderPane.alignment="CENTER">
             <children>
 
-                <Button alignment="BASELINE_LEFT" graphicTextGap="15.0" maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#handleShowDashboard" prefHeight="45.0" style="-fx-background-color: transparent; -fx-cursor: hand;" text="Dashboard" textAlignment="CENTER" textFill="#475569">
+                <!-- Hamburger Toggle Button -->
+                <Button fx:id="btnToggleMenu" alignment="CENTER" contentDisplay="CENTER" maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#handleToggleMenu" prefHeight="50.0" styleClass="hamburger-button" text="☰" textAlignment="CENTER">
                     <font>
-                        <Font size="20.0" />
+                        <Font size="24.0" />
                     </font>
-                    <padding>
-                        <Insets left="20.0" />
-                    </padding>
                     <VBox.margin>
-                        <Insets top="35.0" />
+                        <Insets bottom="10.0" top="10.0" />
                     </VBox.margin>
                 </Button>
 
-                <Button alignment="BASELINE_LEFT" graphicTextGap="15.0" maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#handleShowMovements" prefHeight="45.0" style="-fx-background-color: transparent; -fx-cursor: hand;" text="Movimenti" textAlignment="CENTER" textFill="#475569">
-                    <font>
-                        <Font size="20.0" />
-                    </font>
-                    <padding>
-                        <Insets left="20.0" />
-                    </padding>
+                <!-- Dashboard Button -->
+                <Button fx:id="btnDashboard" alignment="CENTER_LEFT" graphicTextGap="15.0" maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#handleShowDashboard" prefHeight="55.0" styleClass="menu-button" textAlignment="CENTER">
+                    <graphic>
+                        <HBox alignment="CENTER_LEFT" spacing="15.0">
+                            <children>
+                                <Label styleClass="menu-icon" text="◧">
+                                    <font>
+                                        <Font size="24.0" />
+                                    </font>
+                                </Label>
+                                <Label fx:id="lblDashboard" styleClass="menu-text" text="Dashboard">
+                                    <font>
+                                        <Font size="18.0" />
+                                    </font>
+                                </Label>
+                            </children>
+                            <padding>
+                                <Insets left="15.0" />
+                            </padding>
+                        </HBox>
+                    </graphic>
                     <VBox.margin>
-                        <Insets top="35.0" />
+                        <Insets left="8.0" right="8.0" top="5.0" />
                     </VBox.margin>
                 </Button>
 
-                <Button alignment="BASELINE_LEFT" graphicTextGap="15.0" maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#handleShowBudget" prefHeight="45.0" style="-fx-background-color: transparent; -fx-cursor: hand;" text="Budget" textAlignment="CENTER" textFill="#475569">
-                    <font>
-                        <Font size="20.0" />
-                    </font>
-                    <padding>
-                        <Insets left="20.0" />
-                    </padding>
+                <!-- Movimenti Button -->
+                <Button fx:id="btnMovimenti" alignment="CENTER_LEFT" graphicTextGap="15.0" maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#handleShowMovements" prefHeight="55.0" styleClass="menu-button" textAlignment="CENTER">
+                    <graphic>
+                        <HBox alignment="CENTER_LEFT" spacing="15.0">
+                            <children>
+                                <Label styleClass="menu-icon" text="⇄">
+                                    <font>
+                                        <Font size="24.0" />
+                                    </font>
+                                </Label>
+                                <Label fx:id="lblMovimenti" styleClass="menu-text" text="Movimenti">
+                                    <font>
+                                        <Font size="18.0" />
+                                    </font>
+                                </Label>
+                            </children>
+                            <padding>
+                                <Insets left="15.0" />
+                            </padding>
+                        </HBox>
+                    </graphic>
                     <VBox.margin>
-                        <Insets top="35.0" />
+                        <Insets left="8.0" right="8.0" top="5.0" />
                     </VBox.margin>
                 </Button>
 
-                <Button alignment="BASELINE_LEFT" graphicTextGap="15.0" maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#handleShowReport" prefHeight="45.0" style="-fx-background-color: transparent; -fx-cursor: hand;" text="Report" textAlignment="CENTER" textFill="#475569">
-                    <font>
-                        <Font size="20.0" />
-                    </font>
-                    <padding>
-                        <Insets left="20.0" />
-                    </padding>
+                <!-- Budget Button -->
+                <Button fx:id="btnBudget" alignment="CENTER_LEFT" graphicTextGap="15.0" maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#handleShowBudget" prefHeight="55.0" styleClass="menu-button" textAlignment="CENTER">
+                    <graphic>
+                        <HBox alignment="CENTER_LEFT" spacing="15.0">
+                            <children>
+                                <Label styleClass="menu-icon" text="€">
+                                    <font>
+                                        <Font size="24.0" />
+                                    </font>
+                                </Label>
+                                <Label fx:id="lblBudget" styleClass="menu-text" text="Budget">
+                                    <font>
+                                        <Font size="18.0" />
+                                    </font>
+                                </Label>
+                            </children>
+                            <padding>
+                                <Insets left="15.0" />
+                            </padding>
+                        </HBox>
+                    </graphic>
                     <VBox.margin>
-                        <Insets top="35.0" />
+                        <Insets left="8.0" right="8.0" top="5.0" />
                     </VBox.margin>
                 </Button>
 
-                <Button alignment="BASELINE_LEFT" graphicTextGap="15.0" layoutX="10.0" layoutY="216.0" maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#handleShowAccount" prefHeight="45.0" style="-fx-background-color: transparent; -fx-cursor: hand;" text="Account" textAlignment="CENTER" textFill="#475569">
-                    <font>
-                        <Font size="20.0" />
-                    </font>
-                    <padding>
-                        <Insets left="20.0" />
-                    </padding>
+                <!-- Report Button -->
+                <Button fx:id="btnReport" alignment="CENTER_LEFT" graphicTextGap="15.0" maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#handleShowReport" prefHeight="55.0" styleClass="menu-button" textAlignment="CENTER">
+                    <graphic>
+                        <HBox alignment="CENTER_LEFT" spacing="15.0">
+                            <children>
+                                <Label styleClass="menu-icon" text="📊">
+                                    <font>
+                                        <Font size="22.0" />
+                                    </font>
+                                </Label>
+                                <Label fx:id="lblReport" styleClass="menu-text" text="Report">
+                                    <font>
+                                        <Font size="18.0" />
+                                    </font>
+                                </Label>
+                            </children>
+                            <padding>
+                                <Insets left="15.0" />
+                            </padding>
+                        </HBox>
+                    </graphic>
                     <VBox.margin>
-                        <Insets top="35.0" />
+                        <Insets left="8.0" right="8.0" top="5.0" />
                     </VBox.margin>
                 </Button>
+
+                <!-- Account Button -->
+                <Button fx:id="btnAccount" alignment="CENTER_LEFT" graphicTextGap="15.0" maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#handleShowAccount" prefHeight="55.0" styleClass="menu-button" textAlignment="CENTER">
+                    <graphic>
+                        <HBox alignment="CENTER_LEFT" spacing="15.0">
+                            <children>
+                                <Label styleClass="menu-icon" text="⚙">
+                                    <font>
+                                        <Font size="24.0" />
+                                    </font>
+                                </Label>
+                                <Label fx:id="lblAccount" styleClass="menu-text" text="Account">
+                                    <font>
+                                        <Font size="18.0" />
+                                    </font>
+                                </Label>
+                            </children>
+                            <padding>
+                                <Insets left="15.0" />
+                            </padding>
+                        </HBox>
+                    </graphic>
+                    <VBox.margin>
+                        <Insets left="8.0" right="8.0" top="5.0" />
+                    </VBox.margin>
+                </Button>
+
             </children>
             <padding>
-                <Insets top="20.0" />
+                <Insets top="15.0" />
             </padding>
         </VBox>
     </left>

--- a/src/it/unicas/project/template/address/view/RootLayoutController.java
+++ b/src/it/unicas/project/template/address/view/RootLayoutController.java
@@ -3,11 +3,18 @@ package it.unicas.project.template.address.view;
 import it.unicas.project.template.address.MainApp;
 import it.unicas.project.template.address.model.User;
 import it.unicas.project.template.address.model.dao.mysql.DAOMySQLSettings;
+import javafx.animation.KeyFrame;
+import javafx.animation.KeyValue;
+import javafx.animation.Timeline;
 import javafx.fxml.FXML;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Alert.AlertType;
+import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.MenuButton;
+import javafx.scene.control.Tooltip;
+import javafx.scene.layout.VBox;
+import javafx.util.Duration;
 
 public class RootLayoutController {
 
@@ -17,9 +24,66 @@ public class RootLayoutController {
     @FXML private Label lblInitials;
     @FXML private MenuButton btnUser;
 
+    // Sidebar components
+    @FXML private VBox sidebar;
+    @FXML private Button btnToggleMenu;
+    @FXML private Button btnDashboard;
+    @FXML private Button btnMovimenti;
+    @FXML private Button btnBudget;
+    @FXML private Button btnReport;
+    @FXML private Button btnAccount;
+
+    // Menu text labels (to hide when collapsed)
+    @FXML private Label lblDashboard;
+    @FXML private Label lblMovimenti;
+    @FXML private Label lblBudget;
+    @FXML private Label lblReport;
+    @FXML private Label lblAccount;
+
+    private boolean isMenuExpanded = true;
+    private static final double EXPANDED_WIDTH = 220.0;
+    private static final double COLLAPSED_WIDTH = 70.0;
+    private Button currentActiveButton = null;
+
     @FXML
     private void initialize() {
-        // Init
+        // Set initial active button
+        if (btnDashboard != null) {
+            setActiveButton(btnDashboard);
+        }
+
+        // Setup tooltips for collapsed menu
+        setupTooltips();
+    }
+
+    /**
+     * Setup tooltips for menu buttons (shown when collapsed)
+     */
+    private void setupTooltips() {
+        // Create tooltips with custom style
+        Tooltip dashboardTip = createStyledTooltip("Dashboard");
+        Tooltip movimentiTip = createStyledTooltip("Movimenti");
+        Tooltip budgetTip = createStyledTooltip("Budget");
+        Tooltip reportTip = createStyledTooltip("Report");
+        Tooltip accountTip = createStyledTooltip("Account");
+
+        // Apply tooltips to buttons
+        if (btnDashboard != null) Tooltip.install(btnDashboard, dashboardTip);
+        if (btnMovimenti != null) Tooltip.install(btnMovimenti, movimentiTip);
+        if (btnBudget != null) Tooltip.install(btnBudget, budgetTip);
+        if (btnReport != null) Tooltip.install(btnReport, reportTip);
+        if (btnAccount != null) Tooltip.install(btnAccount, accountTip);
+    }
+
+    /**
+     * Create a styled tooltip
+     */
+    private Tooltip createStyledTooltip(String text) {
+        Tooltip tooltip = new Tooltip(text);
+        tooltip.setShowDelay(Duration.millis(300));
+        tooltip.setHideDelay(Duration.millis(100));
+        tooltip.getStyleClass().add("menu-tooltip");
+        return tooltip;
     }
 
     public void setMainApp(MainApp mainApp) {
@@ -67,25 +131,120 @@ public class RootLayoutController {
         if (lblPageTitle != null) lblPageTitle.setText(title);
     }
 
-
-    @FXML private void handleShowDashboard() { if (mainApp != null) mainApp.showDashboard(); }
-    @FXML private void handleShowMovements() { if (mainApp != null) mainApp.showMovimenti(); }
-    @FXML private void handleShowBudget() { if (mainApp != null) mainApp.showBudget(); }
-
-    // --- MENU UTENTE ---
+    /**
+     * Toggle menu expansion/collapse with smooth animation
+     */
     @FXML
-    private void handleSettings() {
-        //  porta alla pagina Account
+    private void handleToggleMenu() {
+        double targetWidth = isMenuExpanded ? COLLAPSED_WIDTH : EXPANDED_WIDTH;
+
+        // Create smooth animation for width change
+        Timeline timeline = new Timeline();
+        KeyValue keyValue = new KeyValue(sidebar.prefWidthProperty(), targetWidth);
+        KeyFrame keyFrame = new KeyFrame(Duration.millis(300), keyValue);
+        timeline.getKeyFrames().add(keyFrame);
+
+        // Animate text visibility
+        if (isMenuExpanded) {
+            // Collapsing: hide text immediately for smooth transition
+            fadeOutLabels();
+            btnToggleMenu.setText("☰");
+        } else {
+            // Expanding: show text after animation starts
+            timeline.setOnFinished(e -> fadeInLabels());
+            btnToggleMenu.setText("✕");
+        }
+
+        timeline.play();
+        isMenuExpanded = !isMenuExpanded;
+    }
+
+    /**
+     * Fade out menu text labels
+     */
+    private void fadeOutLabels() {
+        Label[] labels = {lblDashboard, lblMovimenti, lblBudget, lblReport, lblAccount};
+
+        Timeline fadeTimeline = new Timeline();
+        for (Label label : labels) {
+            if (label != null) {
+                KeyValue kv = new KeyValue(label.opacityProperty(), 0);
+                KeyFrame kf = new KeyFrame(Duration.millis(150), kv);
+                fadeTimeline.getKeyFrames().add(kf);
+            }
+        }
+        fadeTimeline.setOnFinished(e -> {
+            for (Label label : labels) {
+                if (label != null) label.setVisible(false);
+            }
+        });
+        fadeTimeline.play();
+    }
+
+    /**
+     * Fade in menu text labels
+     */
+    private void fadeInLabels() {
+        Label[] labels = {lblDashboard, lblMovimenti, lblBudget, lblReport, lblAccount};
+
+        // First make them visible but transparent
+        for (Label label : labels) {
+            if (label != null) {
+                label.setVisible(true);
+                label.setOpacity(0);
+            }
+        }
+
+        // Then fade in
+        Timeline fadeTimeline = new Timeline();
+        for (Label label : labels) {
+            if (label != null) {
+                KeyValue kv = new KeyValue(label.opacityProperty(), 1);
+                KeyFrame kf = new KeyFrame(Duration.millis(200), kv);
+                fadeTimeline.getKeyFrames().add(kf);
+            }
+        }
+        fadeTimeline.play();
+    }
+
+    /**
+     * Set a button as active and deactivate others
+     */
+    private void setActiveButton(Button button) {
+        // Remove active style from previous button
+        if (currentActiveButton != null) {
+            currentActiveButton.getStyleClass().remove("menu-button-active");
+        }
+
+        // Add active style to new button
+        if (button != null && !button.getStyleClass().contains("menu-button-active")) {
+            button.getStyleClass().add("menu-button-active");
+        }
+
+        currentActiveButton = button;
+    }
+
+    @FXML
+    private void handleShowDashboard() {
         if (mainApp != null) {
-            mainApp.showAccountPage();
+            mainApp.showDashboard();
+            setActiveButton(btnDashboard);
         }
     }
 
+    @FXML
+    private void handleShowMovements() {
+        if (mainApp != null) {
+            mainApp.showMovimenti();
+            setActiveButton(btnMovimenti);
+        }
+    }
 
     @FXML
-    private void handleShowAccount() {
+    private void handleShowBudget() {
         if (mainApp != null) {
-            mainApp.showAccountPage();
+            mainApp.showBudget();
+            setActiveButton(btnBudget);
         }
     }
 
@@ -93,9 +252,27 @@ public class RootLayoutController {
     private void handleShowReport() {
         if (mainApp != null) {
             mainApp.showReport();
+            setActiveButton(btnReport);
         }
     }
 
+    @FXML
+    private void handleShowAccount() {
+        if (mainApp != null) {
+            mainApp.showAccountPage();
+            setActiveButton(btnAccount);
+        }
+    }
+
+    // --- MENU UTENTE ---
+    @FXML
+    private void handleSettings() {
+        //  porta alla pagina Account
+        if (mainApp != null) {
+            mainApp.showAccountPage();
+            setActiveButton(btnAccount);
+        }
+    }
 
     @FXML
     private void handleExit() {

--- a/src/it/unicas/project/template/address/view/css/collapsible-menu.css
+++ b/src/it/unicas/project/template/address/view/css/collapsible-menu.css
@@ -1,0 +1,144 @@
+/* ========================================
+   Collapsible Sidebar Menu Styles
+   ======================================== */
+
+/* Hamburger Toggle Button */
+.hamburger-button {
+    -fx-background-color: transparent;
+    -fx-text-fill: #475569;
+    -fx-cursor: hand;
+    -fx-background-radius: 10px;
+    -fx-border-radius: 10px;
+    -fx-font-weight: bold;
+    -fx-effect: none;
+}
+
+.hamburger-button:hover {
+    -fx-background-color: #f1f5f9;
+    -fx-text-fill: #3b82f6;
+    -fx-scale-x: 1.05;
+    -fx-scale-y: 1.05;
+}
+
+.hamburger-button:pressed {
+    -fx-background-color: #e2e8f0;
+    -fx-scale-x: 0.98;
+    -fx-scale-y: 0.98;
+}
+
+/* Menu Buttons Base Style */
+.menu-button {
+    -fx-background-color: transparent;
+    -fx-cursor: hand;
+    -fx-background-radius: 12px;
+    -fx-border-radius: 12px;
+    -fx-effect: none;
+    -fx-transition: all 0.3s ease;
+}
+
+/* Menu Button Hover Effect */
+.menu-button:hover {
+    -fx-background-color: linear-gradient(to right, #eff6ff, #dbeafe);
+    -fx-effect: dropshadow(gaussian, rgba(59, 130, 246, 0.15), 8, 0, 0, 2);
+    -fx-scale-x: 1.02;
+    -fx-scale-y: 1.02;
+}
+
+/* Menu Button Active State */
+.menu-button-active {
+    -fx-background-color: linear-gradient(to right, #3b82f6, #60a5fa);
+    -fx-effect: dropshadow(gaussian, rgba(59, 130, 246, 0.4), 10, 0, 0, 3);
+}
+
+.menu-button-active:hover {
+    -fx-background-color: linear-gradient(to right, #2563eb, #3b82f6);
+    -fx-effect: dropshadow(gaussian, rgba(59, 130, 246, 0.5), 12, 0, 0, 4);
+}
+
+/* Menu Button Pressed Effect */
+.menu-button:pressed {
+    -fx-scale-x: 0.98;
+    -fx-scale-y: 0.98;
+}
+
+/* Menu Icon Styling */
+.menu-icon {
+    -fx-text-fill: #64748b;
+    -fx-font-weight: bold;
+}
+
+.menu-button:hover .menu-icon {
+    -fx-text-fill: #3b82f6;
+}
+
+.menu-button-active .menu-icon {
+    -fx-text-fill: white;
+}
+
+/* Menu Text Styling */
+.menu-text {
+    -fx-text-fill: #475569;
+    -fx-font-weight: 500;
+}
+
+.menu-button:hover .menu-text {
+    -fx-text-fill: #1e40af;
+    -fx-font-weight: 600;
+}
+
+.menu-button-active .menu-text {
+    -fx-text-fill: white;
+    -fx-font-weight: 600;
+}
+
+/* Sidebar Smooth Transition */
+#sidebar {
+    -fx-transition: -fx-pref-width 0.3s ease;
+}
+
+/* Additional Animation Effects */
+@keyframes slideIn {
+    from {
+        -fx-translate-x: -20px;
+        -fx-opacity: 0;
+    }
+    to {
+        -fx-translate-x: 0px;
+        -fx-opacity: 1;
+    }
+}
+
+@keyframes pulse {
+    0%, 100% {
+        -fx-scale-x: 1;
+        -fx-scale-y: 1;
+    }
+    50% {
+        -fx-scale-x: 1.05;
+        -fx-scale-y: 1.05;
+    }
+}
+
+/* Scrollbar styling for sidebar if needed */
+.menu-scrollpane .scroll-bar:vertical {
+    -fx-background-color: transparent;
+}
+
+.menu-scrollpane .scroll-bar:vertical .thumb {
+    -fx-background-color: #cbd5e1;
+    -fx-background-radius: 5px;
+}
+
+.menu-scrollpane .scroll-bar:vertical .thumb:hover {
+    -fx-background-color: #94a3b8;
+}
+
+/* Tooltip styling for collapsed menu */
+.menu-tooltip {
+    -fx-background-color: #1e293b;
+    -fx-text-fill: white;
+    -fx-padding: 8px 12px;
+    -fx-background-radius: 8px;
+    -fx-font-size: 14px;
+    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.3), 8, 0, 0, 2);
+}


### PR DESCRIPTION
Implemented a beautiful hamburger-style collapsible menu for the sidebar navigation with the following features:

- Added hamburger toggle button (☰/✕) for expanding/collapsing the menu
- Integrated beautiful icons for each menu item:
  - Dashboard: ◧ (grid icon)
  - Movimenti: ⇄ (exchange arrows)
  - Budget: € (euro symbol)
  - Report: 📊 (chart emoji)
  - Account: ⚙ (settings gear)

- Smooth animations:
  - Menu width transitions from 220px (expanded) to 70px (collapsed)
  - Fade in/out effects for menu text labels
  - Smooth hover and active state transitions

- Enhanced UX:
  - Tooltips appear when menu is collapsed
  - Active menu item highlighting with gradient background
  - Beautiful hover effects with subtle shadows and scaling
  - Maintains active state tracking across navigation

- New CSS styling:
  - Created dedicated collapsible-menu.css for menu styles
  - Modern gradient backgrounds for active states
  - Smooth transitions and hover effects
  - Professional color scheme matching the app design

Files modified:
- RootLayout.fxml: Restructured sidebar with icons and toggle button
- RootLayoutController.java: Added toggle logic, animations, and tooltip support
- collapsible-menu.css: New stylesheet with beautiful menu styling