### PR TITLE
Make calendar icon style consistent with other fields

### DIFF
--- a/src/it/unicas/project/template/address/view/Movimenti.fxml
+++ b/src/it/unicas/project/template/address/view/Movimenti.fxml
@@ -52,7 +52,7 @@
                                         <VBox spacing="5.0" HBox.hgrow="ALWAYS">
                                             <children>
                                                 <Label text="Data" textFill="#64748b" />
-                                                <DatePicker fx:id="dateField" maxHeight="26.0" maxWidth="1.7976931348623157E308" prefHeight="26.0" prefWidth="130.0" style="-fx-background-color: transparent;" />
+                                                <DatePicker fx:id="dateField" maxHeight="26.0" maxWidth="1.7976931348623157E308" prefHeight="26.0" prefWidth="130.0" style="-fx-background-color: #f1f5f9; -fx-background-radius: 8;" />
                                             </children>
                                         </VBox>
                                     </children>


### PR DESCRIPTION
Changed DatePicker background color from transparent to #f1f5f9 with 8px border radius to maintain consistency with the modern, minimal design of other form fields in the Movimenti page.