### PR TITLE
Ensure charts retain minimum dimensions

### DIFF
--- a/src/it/unicas/project/template/address/view/Dashboard.fxml
+++ b/src/it/unicas/project/template/address/view/Dashboard.fxml
@@ -194,7 +194,7 @@
                                             </children>
                                         </HBox>
 
-                                        <BarChart fx:id="barChartAndamento" animated="true" barGap="8.0" categoryGap="20.0" legendVisible="true" minHeight="250.0" prefHeight="300.0">
+                                        <BarChart fx:id="barChartAndamento" animated="true" barGap="8.0" categoryGap="20.0" legendVisible="true" minHeight="250.0" minWidth="600.0" prefHeight="300.0" prefWidth="800.0">
                                             <xAxis>
                                                 <CategoryAxis side="BOTTOM" />
                                             </xAxis>
@@ -209,11 +209,11 @@
 
                         <GridPane hgap="30.0" vgap="20.0">
                             <columnConstraints>
-                                <ColumnConstraints hgrow="ALWAYS" percentWidth="60.0" />
-                                <ColumnConstraints hgrow="ALWAYS" percentWidth="40.0" />
+                                <ColumnConstraints hgrow="ALWAYS" minWidth="520.0" prefWidth="560.0" />
+                                <ColumnConstraints hgrow="ALWAYS" minWidth="360.0" prefWidth="400.0" />
                             </columnConstraints>
                             <rowConstraints>
-                                <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
+                                <RowConstraints minHeight="350.0" prefHeight="400.0" vgrow="SOMETIMES" />
                             </rowConstraints>
                             <children>
 

--- a/src/it/unicas/project/template/address/view/Report.fxml
+++ b/src/it/unicas/project/template/address/view/Report.fxml
@@ -27,14 +27,14 @@
                         <!-- CONTENUTO PRINCIPALE - GridPane che si espande -->
                         <GridPane hgap="25.0" vgap="25.0" VBox.vgrow="ALWAYS">
                             <columnConstraints>
-                                <!-- Colonna sinistra: 50% -->
-                                <ColumnConstraints hgrow="ALWAYS" percentWidth="50.0" />
-                                <!-- Colonna destra: 50% -->
-                                <ColumnConstraints hgrow="ALWAYS" percentWidth="50.0" />
+                                <!-- Colonna sinistra con larghezza minima -->
+                                <ColumnConstraints hgrow="ALWAYS" minWidth="440.0" prefWidth="480.0" />
+                                <!-- Colonna destra con larghezza minima -->
+                                <ColumnConstraints hgrow="ALWAYS" minWidth="440.0" prefWidth="480.0" />
                             </columnConstraints>
                             <rowConstraints>
                                 <!-- Unica riga che si espande -->
-                                <RowConstraints minHeight="500.0" vgrow="ALWAYS" />
+                                <RowConstraints minHeight="500.0" prefHeight="520.0" vgrow="ALWAYS" />
                             </rowConstraints>
                             <children>
 
@@ -48,7 +48,7 @@
                                                         <Font name="System Bold" size="18.0" />
                                                     </font>
                                                 </Label>
-                                                <PieChart fx:id="pieChart" legendSide="BOTTOM" minHeight="400.0" style="-fx-background-color: transparent;" VBox.vgrow="ALWAYS" />
+                                                <PieChart fx:id="pieChart" legendSide="BOTTOM" minHeight="400.0" minWidth="420.0" prefHeight="420.0" prefWidth="460.0" style="-fx-background-color: transparent;" VBox.vgrow="ALWAYS" />
                                             </children>
                                         </VBox>
                                     </children>
@@ -74,7 +74,7 @@
                                                                 <ComboBox fx:id="cmbRange" prefWidth="140.0" />
                                                             </children>
                                                         </HBox>
-                                                        <SmoothAreaChart fx:id="lineChartAndamento" animated="false" createSymbols="true" legendVisible="true" minHeight="400.0" style="-fx-background-color: transparent;" VBox.vgrow="ALWAYS" />
+                                                        <SmoothAreaChart fx:id="lineChartAndamento" animated="false" createSymbols="true" legendVisible="true" minHeight="400.0" minWidth="420.0" prefHeight="420.0" prefWidth="480.0" style="-fx-background-color: transparent;" VBox.vgrow="ALWAYS" />
                                                     </children>
                                                 </VBox>
                                             </children>


### PR DESCRIPTION
## Summary
- add consistent min/pref widths to dashboard and report charts
- replace percent-based grid constraints with fixed minimum and preferred sizes to prevent panels from collapsing on resize
- increase row height preferences to preserve vertical space

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f77917eec8333b3f01a34bae32b46)