### PR TITLE
Fix monthly budget notification dismissal logic

### DIFF
--- a/src/it/unicas/project/template/address/util/BudgetNotificationHelper.java
+++ b/src/it/unicas/project/template/address/util/BudgetNotificationHelper.java
@@ -68,8 +68,8 @@ public class BudgetNotificationHelper {
         }
 
         // Il budget è superato: controlla se mostrare la notifica
-        if (prefs.isNotificationDisabled(categoryId)) {
-            // Notifiche disabilitate per questa categoria
+        if (prefs.isNotificationDismissedForCurrentMonth(categoryId, categoryBudget.getBudgetAmount())) {
+            // L'utente ha scelto "Non mostrare più" per questo budget nel mese corrente
             return false;
         }
 
@@ -218,8 +218,9 @@ public class BudgetNotificationHelper {
         // Gestione click
         Optional<ButtonType> result = alert.showAndWait();
         if (result.isPresent() && result.get() == disableButton) {
-            // L'utente ha scelto "Non mostrare più"
-            BudgetNotificationPreferences.getInstance().disableNotificationForCategory(budget.getCategoryId());
+            // L'utente ha scelto "Non mostrare più" per il mese corrente
+            BudgetNotificationPreferences.getInstance()
+                .dismissNotificationForCurrentMonth(budget.getCategoryId(), budget.getBudgetAmount());
         }
     }
 


### PR DESCRIPTION
## Summary
- track per-month budget notification dismissals with awareness of budget increases
- adjust notification helper to honor monthly dismissals and resurface alerts when limits rise again
- expand preference tests for dismissal scope, persistence, and cleanup

## Testing
- javac -d out/test-classes   src/test/java/org/junit/jupiter/api/*.java   src/it/unicas/project/template/address/util/BudgetNotificationPreferences.java   src/it/unicas/project/template/address/util/DateUtil.java   src/test/java/it/unicas/project/template/address/util/*.java   src/test/java/TestRunner.java
- java -cp out/test-classes TestRunner

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f7c11c0dc8333820e7e92139e4d96)