### PR TITLE
Fetch dashboard movements by month

### DIFF
--- a/src/it/unicas/project/template/address/model/dao/mysql/MovimentiDAOMySQLImpl.java
+++ b/src/it/unicas/project/template/address/model/dao/mysql/MovimentiDAOMySQLImpl.java
@@ -134,6 +134,41 @@ public class MovimentiDAOMySQLImpl implements DAO<Movimenti> {
         return lista;
     }
 
+    public List<Movimenti> selectByUserAndMonthYear(int userId, int month, int year) throws SQLException {
+        ArrayList<Movimenti> lista = new ArrayList<>();
+        String query = "SELECT m.*, c.name as cat_name FROM movements m " +
+                "LEFT JOIN categories c ON m.category_id = c.category_id " +
+                "WHERE m.user_id = ? AND MONTH(m.date) = ? AND YEAR(m.date) = ? " +
+                "ORDER BY m.date DESC";
+
+        try (Connection conn = getConnection();
+             PreparedStatement pstmt = conn.prepareStatement(query)) {
+
+            pstmt.setInt(1, userId);
+            pstmt.setInt(2, month);
+            pstmt.setInt(3, year);
+
+            try (ResultSet rs = pstmt.executeQuery()) {
+                while (rs.next()) {
+                    Movimenti mov = new Movimenti(
+                            rs.getInt("movement_id"),
+                            rs.getString("type"),
+                            rs.getDate("date").toLocalDate(),
+                            rs.getFloat("amount"),
+                            rs.getString("title"),
+                            rs.getString("payment_method")
+                    );
+
+                    mov.setCategoryId(rs.getInt("category_id"));
+                    mov.setCategoryName(rs.getString("cat_name"));
+
+                    lista.add(mov);
+                }
+            }
+        }
+        return lista;
+    }
+
     public float getSumByMonth(int userId, int month, int year, String type) throws SQLException {
         float total = 0f;
         String query = "SELECT SUM(amount) FROM movements " +

--- a/src/it/unicas/project/template/address/view/DashboardController.java
+++ b/src/it/unicas/project/template/address/view/DashboardController.java
@@ -150,8 +150,8 @@ public class DashboardController {
                 lblMeseCorrente.setText(nomeMese.substring(0, 1).toUpperCase() + nomeMese.substring(1) + " " + selectedYear);
             }
 
-            List<Movimenti> recent = dao.selectLastByUser(userId, 5);
-            populateRecentMovements(recent);
+            List<Movimenti> monthlyMovements = dao.selectByUserAndMonthYear(userId, selectedMonth, selectedYear);
+            populateRecentMovements(monthlyMovements);
 
             populateBudgetStatus(userId, selectedMonth, selectedYear);
 


### PR DESCRIPTION
## Summary
- fetch dashboard movements for the selected month/year instead of a fixed recent subset
- add DAO query to retrieve user movements for a given month with category info ordered by date

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f809d16a4833384716c9d27ea1163)