### PR TITLE
Add scrollable container to latest movements section

### DIFF
--- a/src/it/unicas/project/template/address/view/Dashboard.fxml
+++ b/src/it/unicas/project/template/address/view/Dashboard.fxml
@@ -260,7 +260,11 @@
                                                     </font>
                                                 </Label>
 
-                                                <VBox fx:id="boxUltimiMovimenti" spacing="15.0" />
+                                                <ScrollPane fitToWidth="true" hbarPolicy="NEVER" prefHeight="300.0" style="-fx-background-color: transparent; -fx-background: transparent; -fx-padding: 0;" vbarPolicy="AS_NEEDED">
+                                                    <content>
+                                                        <VBox fx:id="boxUltimiMovimenti" spacing="15.0" />
+                                                    </content>
+                                                </ScrollPane>
                                             </children>
                                         </VBox>
                                     </children>


### PR DESCRIPTION
## Summary
- wrap the "Ultimi Movimenti" VBox in a scroll pane to allow scrolling within the card
- configure fit-to-width and preferred height to keep the card compact while scrolling items

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f809fa3688333bfbc913e47dadc35)