### PR TITLE
Adjust recent movements scrollbar spacing

### DIFF
--- a/src/it/unicas/project/template/address/view/Dashboard.fxml
+++ b/src/it/unicas/project/template/address/view/Dashboard.fxml
@@ -252,7 +252,7 @@
 
                                 <AnchorPane style="-fx-background-color: white; -fx-background-radius: 12; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.05), 10, 0, 0, 5);" GridPane.columnIndex="1">
                                     <children>
-                                        <VBox spacing="15.0" AnchorPane.bottomAnchor="25.0" AnchorPane.leftAnchor="25.0" AnchorPane.rightAnchor="25.0" AnchorPane.topAnchor="25.0">
+                                        <VBox spacing="15.0" AnchorPane.bottomAnchor="25.0" AnchorPane.leftAnchor="25.0" AnchorPane.rightAnchor="20.0" AnchorPane.topAnchor="25.0">
                                             <children>
                                                 <Label text="Ultimi Movimenti" textFill="#1e293b">
                                                     <font>


### PR DESCRIPTION
## Summary
- reduce right padding in the recent movements card to align the scrollbar closer to the card edge

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f80307bdc8333ae195840c40a5b9d)