### PR TITLE
Add padding between recent amounts and scrollbar

### DIFF
--- a/bin/it/unicas/project/template/address/view/Dashboard.fxml
+++ b/bin/it/unicas/project/template/address/view/Dashboard.fxml
@@ -232,7 +232,7 @@
                                                     </children>
                                                 </HBox>
 
-                                                <ScrollPane fitToWidth="true" hbarPolicy="NEVER" prefHeight="300.0" style="-fx-background-color: transparent; -fx-background: transparent; -fx-padding: 0;" vbarPolicy="AS_NEEDED">
+                                                <ScrollPane fitToWidth="true" hbarPolicy="NEVER" prefHeight="300.0" style="-fx-background-color: transparent; -fx-background: transparent; -fx-padding: 0 10 0 0;" vbarPolicy="AS_NEEDED">
                                                     <content>
                                                         <GridPane fx:id="gridBudgetList" hgap="15.0" vgap="15.0">
                                                             <columnConstraints>
@@ -252,7 +252,7 @@
 
                                 <AnchorPane style="-fx-background-color: white; -fx-background-radius: 12; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.05), 10, 0, 0, 5);" GridPane.columnIndex="1">
                                     <children>
-                                        <VBox spacing="15.0" AnchorPane.bottomAnchor="25.0" AnchorPane.leftAnchor="25.0" AnchorPane.rightAnchor="25.0" AnchorPane.topAnchor="25.0">
+                                        <VBox spacing="15.0" AnchorPane.bottomAnchor="25.0" AnchorPane.leftAnchor="25.0" AnchorPane.rightAnchor="20.0" AnchorPane.topAnchor="25.0">
                                             <children>
                                                 <Label text="Ultimi Movimenti" textFill="#1e293b">
                                                     <font>
@@ -260,7 +260,11 @@
                                                     </font>
                                                 </Label>
 
-                                                <VBox fx:id="boxUltimiMovimenti" spacing="15.0" />
+                                                <ScrollPane fitToWidth="true" hbarPolicy="NEVER" prefHeight="300.0" style="-fx-background-color: transparent; -fx-background: transparent; -fx-padding: 0 12 0 0;" vbarPolicy="AS_NEEDED">
+                                                    <content>
+                                                        <VBox fx:id="boxUltimiMovimenti" spacing="15.0" />
+                                                    </content>
+                                                </ScrollPane>
                                             </children>
                                         </VBox>
                                     </children>

--- a/src/it/unicas/project/template/address/view/Dashboard.fxml
+++ b/src/it/unicas/project/template/address/view/Dashboard.fxml
@@ -232,7 +232,7 @@
                                                     </children>
                                                 </HBox>
 
-                                                <ScrollPane fitToWidth="true" hbarPolicy="NEVER" prefHeight="300.0" style="-fx-background-color: transparent; -fx-background: transparent; -fx-padding: 0;" vbarPolicy="AS_NEEDED">
+                                                <ScrollPane fitToWidth="true" hbarPolicy="NEVER" prefHeight="300.0" style="-fx-background-color: transparent; -fx-background: transparent; -fx-padding: 0 10 0 0;" vbarPolicy="AS_NEEDED">
                                                     <content>
                                                         <GridPane fx:id="gridBudgetList" hgap="15.0" vgap="15.0">
                                                             <columnConstraints>
@@ -252,7 +252,7 @@
 
                                 <AnchorPane style="-fx-background-color: white; -fx-background-radius: 12; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.05), 10, 0, 0, 5);" GridPane.columnIndex="1">
                                     <children>
-                                        <VBox spacing="15.0" AnchorPane.bottomAnchor="25.0" AnchorPane.leftAnchor="25.0" AnchorPane.rightAnchor="25.0" AnchorPane.topAnchor="25.0">
+                                        <VBox spacing="15.0" AnchorPane.bottomAnchor="25.0" AnchorPane.leftAnchor="25.0" AnchorPane.rightAnchor="20.0" AnchorPane.topAnchor="25.0">
                                             <children>
                                                 <Label text="Ultimi Movimenti" textFill="#1e293b">
                                                     <font>
@@ -260,7 +260,7 @@
                                                     </font>
                                                 </Label>
 
-                                                <ScrollPane fitToWidth="true" hbarPolicy="NEVER" prefHeight="300.0" style="-fx-background-color: transparent; -fx-background: transparent; -fx-padding: 0;" vbarPolicy="AS_NEEDED">
+                                                <ScrollPane fitToWidth="true" hbarPolicy="NEVER" prefHeight="300.0" style="-fx-background-color: transparent; -fx-background: transparent; -fx-padding: 0 12 0 0;" vbarPolicy="AS_NEEDED">
                                                     <content>
                                                         <VBox fx:id="boxUltimiMovimenti" spacing="15.0" />
                                                     </content>


### PR DESCRIPTION
## Summary
- add right padding in dashboard scroll areas to move list content away from the scrollbar
- ensure recent movements list retains scrolling while keeping values spaced from the edge

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f80307bdc8333ae195840c40a5b9d)