### PR TITLE
Limit line chart animation to plot area

### DIFF
--- a/src/it/unicas/project/template/address/view/ReportController.java
+++ b/src/it/unicas/project/template/address/view/ReportController.java
@@ -231,8 +231,9 @@ public class ReportController {
                 }
 
                 Node plotArea = findPlotArea(plotBackground);
+                // Limitiamo il clip solo all'area del grafico, non agli assi
                 if (plotArea == null) {
-                    plotArea = plotBackground.getParent();
+                    plotArea = plotBackground;
                 }
 
                 Rectangle clip = new Rectangle();


### PR DESCRIPTION
## Summary
- restrict the line chart reveal animation to the plot area so axes remain visible

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f854aaad083339a38cdc9fdf3803e)