### PR TITLE
Fix menu text color and size styling

### DIFF
--- a/bin/it/unicas/project/template/address/view/RootLayout.fxml
+++ b/bin/it/unicas/project/template/address/view/RootLayout.fxml
@@ -143,7 +143,7 @@
                                 </SVGPath>
                                 <Label fx:id="lblDashboard" styleClass="menu-text" text="Dashboard">
                                     <font>
-                                        <Font name="System Bold" size="17.0" />
+                                        <Font name="System Bold" size="22.0" />
                                     </font>
                                 </Label>
                             </children>
@@ -170,7 +170,7 @@
                                 </SVGPath>
                                 <Label fx:id="lblMovimenti" styleClass="menu-text" text="Movimenti">
                                     <font>
-                                        <Font name="System Bold" size="17.0" />
+                                        <Font name="System Bold" size="22.0" />
                                     </font>
                                 </Label>
                             </children>
@@ -197,7 +197,7 @@
                                 </SVGPath>
                                 <Label fx:id="lblBudget" styleClass="menu-text" text="Budget">
                                     <font>
-                                        <Font name="System Bold" size="17.0" />
+                                        <Font name="System Bold" size="22.0" />
                                     </font>
                                 </Label>
                             </children>
@@ -224,7 +224,7 @@
                                 </SVGPath>
                                 <Label fx:id="lblReport" styleClass="menu-text" text="Report">
                                     <font>
-                                        <Font name="System Bold" size="17.0" />
+                                        <Font name="System Bold" size="22.0" />
                                     </font>
                                 </Label>
                             </children>
@@ -268,7 +268,7 @@
                                 </SVGPath>
                                 <Label fx:id="lblAccount" styleClass="menu-text" text="Account">
                                     <font>
-                                        <Font name="System Bold" size="17.0" />
+                                        <Font name="System Bold" size="22.0" />
                                     </font>
                                 </Label>
                             </children>

--- a/bin/it/unicas/project/template/address/view/css/collapsible-menu.css
+++ b/bin/it/unicas/project/template/address/view/css/collapsible-menu.css
@@ -76,6 +76,7 @@
 .menu-text {
     -fx-text-fill: #334155;
     -fx-font-weight: 600;
+    -fx-font-size: 22px;
 }
 
 .menu-button:hover .menu-text {
@@ -131,8 +132,26 @@
 .menu-button-active:focused .menu-text,
 .menu-button-active:pressed .menu-text,
 .menu-button-active:hover:focused .menu-text {
-    -fx-text-fill: white;
+    -fx-text-fill: #FFFFFF;
     -fx-font-weight: 600;
+    -fx-font-size: 22px;
+}
+
+/* Regola specifica per Label dentro bottoni attivi (maggiore specificità) */
+.menu-button-active .menu-item-container .menu-text {
+    -fx-text-fill: #FFFFFF;
+}
+
+.menu-button-active:hover .menu-item-container .menu-text {
+    -fx-text-fill: #FFFFFF;
+}
+
+.menu-button-active:focused .menu-item-container .menu-text {
+    -fx-text-fill: #FFFFFF;
+}
+
+.menu-button-active:pressed .menu-item-container .menu-text {
+    -fx-text-fill: #FFFFFF;
 }
 
 /* ============= MENU ITEM CONTAINER ============= */

--- a/src/it/unicas/project/template/address/view/RootLayout.fxml
+++ b/src/it/unicas/project/template/address/view/RootLayout.fxml
@@ -143,7 +143,7 @@
                                 </SVGPath>
                                 <Label fx:id="lblDashboard" styleClass="menu-text" text="Dashboard">
                                     <font>
-                                        <Font name="System Bold" size="17.0" />
+                                        <Font name="System Bold" size="22.0" />
                                     </font>
                                 </Label>
                             </children>
@@ -170,7 +170,7 @@
                                 </SVGPath>
                                 <Label fx:id="lblMovimenti" styleClass="menu-text" text="Movimenti">
                                     <font>
-                                        <Font name="System Bold" size="17.0" />
+                                        <Font name="System Bold" size="22.0" />
                                     </font>
                                 </Label>
                             </children>
@@ -197,7 +197,7 @@
                                 </SVGPath>
                                 <Label fx:id="lblBudget" styleClass="menu-text" text="Budget">
                                     <font>
-                                        <Font name="System Bold" size="17.0" />
+                                        <Font name="System Bold" size="22.0" />
                                     </font>
                                 </Label>
                             </children>
@@ -224,7 +224,7 @@
                                 </SVGPath>
                                 <Label fx:id="lblReport" styleClass="menu-text" text="Report">
                                     <font>
-                                        <Font name="System Bold" size="17.0" />
+                                        <Font name="System Bold" size="22.0" />
                                     </font>
                                 </Label>
                             </children>
@@ -268,7 +268,7 @@
                                 </SVGPath>
                                 <Label fx:id="lblAccount" styleClass="menu-text" text="Account">
                                     <font>
-                                        <Font name="System Bold" size="17.0" />
+                                        <Font name="System Bold" size="22.0" />
                                     </font>
                                 </Label>
                             </children>

--- a/src/it/unicas/project/template/address/view/css/collapsible-menu.css
+++ b/src/it/unicas/project/template/address/view/css/collapsible-menu.css
@@ -76,6 +76,7 @@
 .menu-text {
     -fx-text-fill: #334155;
     -fx-font-weight: 600;
+    -fx-font-size: 22px;
 }
 
 .menu-button:hover .menu-text {
@@ -131,8 +132,26 @@
 .menu-button-active:focused .menu-text,
 .menu-button-active:pressed .menu-text,
 .menu-button-active:hover:focused .menu-text {
-    -fx-text-fill: white;
+    -fx-text-fill: #FFFFFF;
     -fx-font-weight: 600;
+    -fx-font-size: 22px;
+}
+
+/* Regola specifica per Label dentro bottoni attivi (maggiore specificità) */
+.menu-button-active .menu-item-container .menu-text {
+    -fx-text-fill: #FFFFFF;
+}
+
+.menu-button-active:hover .menu-item-container .menu-text {
+    -fx-text-fill: #FFFFFF;
+}
+
+.menu-button-active:focused .menu-item-container .menu-text {
+    -fx-text-fill: #FFFFFF;
+}
+
+.menu-button-active:pressed .menu-item-container .menu-text {
+    -fx-text-fill: #FFFFFF;
 }
 
 /* ============= MENU ITEM CONTAINER ============= */


### PR DESCRIPTION
- Aumenta dimensione font voci menu da 17pt a 22pt per migliore leggibilità
- Corregge colore testo menu che ora diventa bianco quando voce è selezionata
- Aggiunge regole CSS con maggiore specificità per garantire applicazione stile attivo
- Applica modifiche sia a FXML che a CSS per consistenza